### PR TITLE
Feat: 키보드 대응을 위한 useKeyboardAwareView 훅 구현

### DIFF
--- a/src/components/common/FullHeight/index.tsx
+++ b/src/components/common/FullHeight/index.tsx
@@ -1,0 +1,35 @@
+import { HTMLAttributes, ReactNode, useLayoutEffect, useState } from "react";
+import styled from "styled-components";
+import { themeConfig } from "styles/themeConfig";
+
+/**
+ * height가 window.innerHeight인 div 컨테이너
+ *
+ * 모바일 화면을 꽉 채우는 페이지를 구현할 때 사용합니다.
+ */
+export const FullHeight = ({
+  children,
+  ...props
+}: { children: ReactNode } & HTMLAttributes<HTMLDivElement>) => {
+  const [height, setHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    setHeight(window.innerHeight);
+  }, []);
+
+  return (
+    <StyledComp height={height} {...props}>
+      {children}
+    </StyledComp>
+  );
+};
+
+const StyledComp = styled.div.withConfig({
+  shouldForwardProp: (prop) => !["height"].includes(prop)
+})<{ height?: number }>`
+  max-width: ${themeConfig.breakPoints.md};
+  height: ${({ height }) => (height ? `${height}px` : "100dvh")};
+  margin: 0 auto;
+  position: relative;
+  overflow: hidden;
+`;

--- a/src/components/common/Layout/index.tsx
+++ b/src/components/common/Layout/index.tsx
@@ -5,12 +5,11 @@ import { StyledContainer } from "./styles";
 import type { ColorProps, SpacingProps } from "styles/system";
 
 /**
- * type: global - App에서 사용
  * type: main - 메인 페이지에서 사용 (with NavBar)
  * type: detail - 상세 페이지에서 사용 (without NavBar)
  */
 export interface LayoutProps extends ColorProps, SpacingProps {
-  type?: "global" | "main" | "detail";
+  type?: "main" | "detail";
 }
 
 export const Layout = ({ type = "detail", children, ...props }: PropsWithChildren<LayoutProps>) => {

--- a/src/components/common/Layout/styles.ts
+++ b/src/components/common/Layout/styles.ts
@@ -38,27 +38,16 @@ export const StyledContainer = styled.div.withConfig({
   ${(props) => getPaddingStyle(props)};
 
   ${({ type }) =>
-    type === "global" &&
-    css`
-      max-width: ${themeConfig.breakPoints.md};
-      min-height: 100%;
-      margin: 0 auto;
-    `}
-
-  ${({ type }) =>
     type === "main" &&
     css`
       width: 100%;
-      height: calc(100vh - 78px - 48px);
-      min-height: 100%;
+      height: calc(100% - 78px - 48px);
     `}
-
 
   ${({ type }) =>
     type === "detail" &&
     css`
       width: 100%;
-      height: calc(100vh - 48px);
-      min-height: 100%;
+      height: calc(100% - 48px);
     `}
 `;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -8,3 +8,4 @@ export * from "./progress";
 export * from "./Carousel";
 export * from "./Accordion";
 export * from "./Checkbox";
+export * from "./FullHeight";

--- a/src/hooks/common/useKeyboardAwareView.ts
+++ b/src/hooks/common/useKeyboardAwareView.ts
@@ -1,0 +1,118 @@
+import { useState, useEffect, useCallback, useRef, type CSSProperties } from "react";
+
+interface UseKeyboardAwareViewResult {
+  isKeyboardOpen: boolean;
+  viewportHeight: number;
+  translateY: number;
+  style: CSSProperties;
+}
+
+/**
+ * 키보드 활성화에 대응하는 뷰를 위한 훅
+ *
+ * 모바일 환경에서 가상 키보드의 열림/닫힘 상태를 감지하고,
+ * 뷰포트의 크기 변화와 스크롤 위치를 추적합니다.
+ * iOS와 Android 플랫폼 모두에서 작동하도록 설계되었습니다.
+ *
+ * @returns {UseKeyboardAwareViewResult} 키보드 대응 상태 객체 및 스타일
+ * @property {boolean} isKeyboardOpen - 가상 키보드 활성화 여부
+ * @property {number} viewportHeight - 현재 뷰포트의 높이
+ * @property {number} translateY - 스크롤에 따른 Y축 변환 값
+ * @property {Object} style - 적용할 스타일 객체
+ */
+export const useKeyboardAwareView = (): UseKeyboardAwareViewResult => {
+  const [state, setState] = useState({
+    isKeyboardOpen: false,
+    viewportHeight: window.innerHeight,
+    translateY: 0
+  });
+
+  const initialClientHeight = useRef(window.innerHeight);
+
+  const getVisualViewport = useCallback(() => window.visualViewport, []);
+
+  const isIOS = /iOS|iPad|iPhone|iPod/.test(window.navigator.userAgent);
+  const isAndroid = /Android/.test(window.navigator.userAgent);
+
+  const handleResize = useCallback(() => {
+    const visualViewport = getVisualViewport();
+    if (!visualViewport) return;
+
+    const windowHeight = window.innerHeight;
+    const viewportHeight = visualViewport.height;
+
+    const isIOSKeyboardOpen = isIOS && windowHeight > viewportHeight;
+    const isAndroidKeyboardOpen = isAndroid && viewportHeight < initialClientHeight.current;
+    const isKeyboardOpen = isIOSKeyboardOpen || isAndroidKeyboardOpen;
+
+    setState((prevState) => ({
+      ...prevState,
+      isKeyboardOpen,
+      viewportHeight,
+      translateY: isKeyboardOpen ? prevState.translateY : 0
+    }));
+  }, [getVisualViewport, isIOS, isAndroid]);
+
+  const handleScroll = useCallback(() => {
+    if (!state.isKeyboardOpen) return;
+
+    const visualViewport = getVisualViewport();
+    if (!visualViewport) return;
+
+    const viewportTopGap = visualViewport.pageTop - visualViewport.offsetTop;
+    const newTranslateY = window.scrollY - viewportTopGap;
+
+    // 가상 영역까지 스크롤 내려가는 것을 방지
+    if (window.scrollY + visualViewport.height > document.body.offsetHeight - 2) {
+      window.scrollTo(0, document.body.offsetHeight - visualViewport.height - 1);
+    }
+
+    setState((prevState) => ({ ...prevState, translateY: newTranslateY }));
+  }, [state.isKeyboardOpen, getVisualViewport]);
+
+  const handleViewportScroll = useCallback(
+    (e: Event) => {
+      if (!state.isKeyboardOpen) return;
+      const target = e.target as VisualViewport;
+      const viewportScrollY = Math.round(target.offsetTop);
+
+      setState((prevState) => ({ ...prevState, translateY: viewportScrollY }));
+    },
+    [state.isKeyboardOpen]
+  );
+
+  useEffect(() => {
+    const visualViewport = getVisualViewport();
+    if (!visualViewport) return;
+
+    handleResize();
+    visualViewport.addEventListener("resize", handleResize);
+    visualViewport.addEventListener("scroll", handleViewportScroll);
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      visualViewport.removeEventListener("resize", handleResize);
+      visualViewport.removeEventListener("scroll", handleViewportScroll);
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [handleResize, handleScroll, handleViewportScroll, getVisualViewport]);
+
+  const fixedElStyle: CSSProperties = {
+    position: "fixed",
+    bottom: state.isKeyboardOpen ? `calc(100% - ${state.viewportHeight}px)` : "0",
+    left: 0,
+    right: 0,
+    transform: state.isKeyboardOpen ? `translateY(${state.translateY}px)` : "none",
+    transition: isIOS
+      ? `bottom ${KEYBOARD_ANIMATION_DURATION}ms cubic-bezier(${KEYBOARD_ANIMATION_BEZIER.join(",")}), transform 0.1s ease-out`
+      : "bottom 0.1s ease-out", // iOS가 아닌 경우 애니메이션 없음
+    opacity: state.isKeyboardOpen ? 1 : 0,
+    pointerEvents: state.isKeyboardOpen ? "auto" : "none",
+    borderRadius: "0"
+  };
+
+  return { ...state, style: fixedElStyle };
+};
+
+const KEYBOARD_ANIMATION_DURATION = 300;
+const KEYBOARD_ANIMATION_BEZIER = [0.41, 0.75, 0.82, 1];

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -4,7 +4,7 @@ import { PATH } from "constants/path";
 
 import ApiErrorBoundary from "ApiErrorBoundary";
 import App from "App";
-import { Layout } from "components/common";
+import { FullHeight } from "components/common";
 import * as Pages from "pages";
 import LoaderErrorPage from "pages/ErrorPage/LoaderErrorPage";
 import { Suspense } from "react";
@@ -17,16 +17,16 @@ const AppRouter = ({ queryClient }: { queryClient: QueryClient }) => {
   const router = createBrowserRouter([
     {
       element: (
-        <Layout type="global">
+        <FullHeight>
           <ApiErrorBoundary>
             <App />
           </ApiErrorBoundary>
-        </Layout>
+        </FullHeight>
       ),
       errorElement: (
-        <Layout type="global">
+        <FullHeight>
           <LoaderErrorPage />
-        </Layout>
+        </FullHeight>
       ),
       children: [
         {

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -110,8 +110,16 @@ body {
   border-radius: 10px;
 }
 
-  #root {
-    width: 100vw;
-    height: 100vh;
+html,
+body {
+  height: 100vh;
+}
+
+#root {
+  width: 100%;
+  height: 100vh;
+  top: 0;
+  left: 0;
+  overflow: hidden;
   }
 `;


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

모바일 환경에서 가상 키보드 활성화 시 레이아웃 문제를 해결하기 위한 훅을 구현 합니다.
이를 통해 키보드가 나타날 때 UI 요소들이 적절히 대응 될 수 있도록 합니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
- [x] refactor: Layout 컴포넌트 global 타입 제거
  • Layout 컴포넌트에서 사용되지 않는 global 타입을 제거하여 코드를 정리했습니다.

- [x] feat: FullHeight 컴포넌트 추가
    • 모바일 화면을 꽉 채우는 페이지 구현을 위한 FullHeight 컴포넌트를 추가했습니다.
    • `window.innerHeight`를 사용하여 동적으로 높이를 설정합니다.

- [x] feat: useKeyboardAwareView 훅 구현  →  [9d19174](https://github.com/PetCampus-Inc/daeng_v1_front/pull/201/commits/9d191749937c7451f26df63baf0983fa10c20cfc)
  • 키보드 여부를 감지하고, 키보드를 제외한 화면에 보이는 영역을 구하는 훅을 구현했습니다.
  • iOS와 Android 환경을 모두 고려하여 구현했습니다.
  • 키보드 애니메이션 처리를 위한 transition 효과를 추가했습니다.
<br />

#### useKeyboardAwareView 훅 
- 이 훅은 키보드 상태를 감지하고 적절한 스타일을 제공하여 새 버튼이 키보드 위에 올바르게 위치하도록 합니다.
- 두개의 버튼을 사용합니다. 하나는 항상 표시되는 기본 버튼, 다른 하나는 키보드 활성화 시 나타나는 버튼입니다.
- 키보드가 활성화되면, 기본 버튼은 키보드에 가려지고 새로운 버튼이 키보드 위에 나타납니다.

[📚 기술 문서로 보기](https://www.notion.so/useKeyboardAwareView-b4503d68df66466fb2dc5d1769dfe306?pvs=4)
<br />

- 가상 키보드 비활성화: 기존의 고정된 하단 요소가 정상적으로 표시.
- 가상 키보드 활성화:
  - 기존의 고정된 하단 요소는 키보드에 가려짐.
  - 새로운 요소(또는 스타일이 변경된 기존 요소)가 키보드 위에 나타남.

**사용 방법**
훅에서 제공하는 style 객체를 직접 사용하거나, 필요에 따라 커스텀 할 수 있습니다.

1. style 객체를 그대로 사용
```js
const { style } = useKeyboardAwareView();

return (
  <>
    {/* 항상 표시되는 기본 버튼 */}
    <StyledButton type="submit" onClick={handleSubmit}>
      로그인
    </StyledButton>

    {/* 키보드가 활성화될 때만 나타나는 버튼 */}
    <StyledButton type="submit" onClick={handleSubmit} style={style}>
      로그인
    </StyledButton>
  </>
);
```

2. 커스텀해서 사용하는 방법

```js
const { isKeyboardOpen, viewportHeight, translateY } = useKeyboardAwareView();

return (
  <>
    {/* 항상 표시되는 기본 버튼 */}
    <StyledButton type="submit" onClick={handleSubmit}>
      로그인
    </StyledButton>

    {/* 키보드가 활성화될 때만 나타나는 버튼 */}
    {isKeyboardOpen && (
      <StyledButton
        type="submit"
        onClick={handleSubmit}
        style={{
          position: "fixed",
          bottom: `calc(100% - ${viewportHeight}px)`,
          transform: `translateY(${translateY}px)`,
        }}
      >
        로그인
      </StyledButton>
    )}
  </>
);
```

**유의할 점**
- 기존 하단 요소는 `position: absolute` 여야 합니다.
- 새로운 하단 요소는 `position: fixed` 여야 합니다.

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

1. 가상키보드 여백문제가 남아있어서, 웹에서 스크롤이 감지되면 키보드가 닫히도록 처리가 필요할 것 같습니다
2. ios 키보드 애니메이션과 버튼의 애니메이션이 달라서 어색함이 있습니다 😢 ios 키보드 베지어 값 찾아도 안나오네요
  임시로 비슷한 값 찾아서 넣었습니당..

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->

https://github.com/user-attachments/assets/07bad3e7-f6d6-4ef4-b8d8-b763cb5f04af
####  IOS 테스트


https://github.com/user-attachments/assets/98c2ae36-9498-41b6-80d0-628d54adebca
#### AOS 테스트

@jieun419 @hyerani @seongnam95 