### PR TITLE
Feat: `홈` 등원기록 Weekly Calendar 및 Swipe 기능 구현

### DIFF
--- a/src/assets/svg/arrow-down-icon.tsx
+++ b/src/assets/svg/arrow-down-icon.tsx
@@ -1,4 +1,10 @@
-const ArrowDownIcon = ({ className = "", w = "17", h = "16" }) => {
+import type { IconSize } from "./types";
+
+interface IconProps extends IconSize {
+  className?: string;
+}
+
+const ArrowDownIcon = ({ className = "", w = "16", h = "16" }: IconProps) => {
   return (
     <svg
       className={className}
@@ -6,7 +12,7 @@ const ArrowDownIcon = ({ className = "", w = "17", h = "16" }) => {
       width={w}
       height={h}
       fill="none"
-      viewBox="0 0 17 16"
+      viewBox="0 0 16 16"
     >
       <path
         fill="currentColor"

--- a/src/components/Admin/DogDetailInfo/DogInfo/Calendar/index.tsx
+++ b/src/components/Admin/DogDetailInfo/DogInfo/Calendar/index.tsx
@@ -5,8 +5,7 @@ import { useLocation, useSearchParams } from "react-router-dom";
 
 import * as S from "./styles";
 
-type ValuePiece = Date | null;
-type Value = ValuePiece | [ValuePiece, ValuePiece];
+import type { Value } from "react-calendar/dist/cjs/shared/types";
 
 const Calendar = () => {
   const today = new Date();

--- a/src/components/Admin/DogDetailInfo/DogInfo/styles.ts
+++ b/src/components/Admin/DogDetailInfo/DogInfo/styles.ts
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import "react-calendar/dist/Calendar.css";
 
 export const Container = styled.div`
   display: flex;

--- a/src/components/Agenda/Calendar/Calendar.tsx
+++ b/src/components/Agenda/Calendar/Calendar.tsx
@@ -5,7 +5,7 @@ import React, { useState, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import { MonthlyCalendar } from "./MonthlyCalendar";
-import { MonthSelector } from "./MonthSelector";
+import { MonthPicker } from "./MonthPicker";
 import { ToggleViewButton } from "./styles";
 import { WeeklyCalendar } from "./WeeklyCalendar";
 
@@ -14,15 +14,15 @@ import type { Value } from "react-calendar/dist/cjs/shared/types";
 export const Calendar: React.FC = () => {
   const today = new Date();
   const [expanded, setExpanded] = useState(false);
-  const [activeStartDate, setActiveStartDate] = useState<Date | null>(new Date());
+  const [activeDate, setActiveDate] = useState<Date | null>(new Date());
   const [searchParams, setSearchParams] = useSearchParams();
-  const [showMonthSelector, setShowMonthSelector] = useState(false);
+  const [showMonthPicker, setShowMonthPicker] = useState(false);
   const calendarHeaderRef = useRef<HTMLDivElement>(null);
 
-  const handleDateClick = (newDate: Value) => {
-    if (newDate instanceof Date) {
-      setActiveStartDate(newDate);
-      const formattedDate = format(newDate as Date, "yyyy-MM-dd");
+  const handleDateClick = (date: Value) => {
+    if (date instanceof Date) {
+      setActiveDate(date);
+      const formattedDate = format(date as Date, "yyyy-MM-dd");
       searchParams.set("date", formattedDate);
       setSearchParams(searchParams);
     }
@@ -30,46 +30,48 @@ export const Calendar: React.FC = () => {
 
   const handleTodayClick = () => {
     const today = new Date();
-    setActiveStartDate(today);
+    handleDateClick(today);
   };
 
   const toggleExpanded = () => setExpanded((prev) => !prev);
 
-  const handleMonthSelect = (value: Value) => {
-    if (value instanceof Date) {
-      setActiveStartDate(value);
-      setShowMonthSelector(false);
-    }
+  const handleMonthClick = (date: Value) => {
+    handleDateClick(date);
+    setShowMonthPicker(false);
   };
 
-  const handleCloseMonthSelector = () => {
-    setShowMonthSelector(false);
+  const handleOpenMonthPicker = () => {
+    setShowMonthPicker(true);
   };
 
-  const calendarData = {
+  const handleCloseMonthPicker = () => {
+    setShowMonthPicker(false);
+  };
+
+  const calendarProps = {
     today,
     onDateClick: handleDateClick,
     onTodayClick: handleTodayClick,
-    activeStartDate,
-    onActiveStartDateChange: setActiveStartDate,
-    onShowMonthSelectChange: setShowMonthSelector,
+    activeDate,
+    onActiveDateChange: setActiveDate,
+    onOpenMonthPicker: handleOpenMonthPicker,
     headerRef: calendarHeaderRef
   };
 
   return (
     <Box bgColor="white" pt={28} radius="0px 0px 20px 20px">
-      {expanded ? <MonthlyCalendar data={calendarData} /> : <WeeklyCalendar data={calendarData} />}
+      {expanded ? <MonthlyCalendar {...calendarProps} /> : <WeeklyCalendar {...calendarProps} />}
       <ToggleViewButton type="button" onClick={toggleExpanded} expand={expanded}>
         {expanded ? "닫기" : "펼쳐보기"}
         <span>
           <ArrowDownIcon w={20} h={20} />
         </span>
       </ToggleViewButton>
-      <MonthSelector
-        isOpen={showMonthSelector}
-        onClose={handleCloseMonthSelector}
-        activeStartDate={activeStartDate}
-        onSelect={handleMonthSelect}
+      <MonthPicker
+        isOpen={showMonthPicker}
+        onClose={handleCloseMonthPicker}
+        onMonthClick={handleMonthClick}
+        activeDate={activeDate}
         anchorRef={calendarHeaderRef}
       />
     </Box>

--- a/src/components/Agenda/Calendar/Calendar.tsx
+++ b/src/components/Agenda/Calendar/Calendar.tsx
@@ -1,23 +1,25 @@
+import ArrowDownIcon from "assets/svg/arrow-down-icon";
 import { Box } from "components/common";
 import { format } from "date-fns";
-import { useState } from "react";
+import React, { useState, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import { MonthlyCalendar } from "./MonthlyCalendar";
+import { MonthSelector } from "./MonthSelector";
+import { ToggleViewButton } from "./styles";
 import { WeeklyCalendar } from "./WeeklyCalendar";
 
-type ValuePiece = Date | null;
-type Value = ValuePiece | [ValuePiece, ValuePiece];
+import type { Value } from "react-calendar/dist/cjs/shared/types";
 
-export const Calendar = () => {
+export const Calendar: React.FC = () => {
   const today = new Date();
-  const [view, setView] = useState<"week" | "month">("week");
-  // 월이 바뀔때 view가 변경되려면 activeStartDate를 업데이트 시켜줘야함
-
+  const [expanded, setExpanded] = useState(false);
   const [activeStartDate, setActiveStartDate] = useState<Date | null>(new Date());
   const [searchParams, setSearchParams] = useSearchParams();
+  const [showMonthSelector, setShowMonthSelector] = useState(false);
+  const calendarHeaderRef = useRef<HTMLDivElement>(null);
 
-  const handleDateChange = (newDate: Value) => {
+  const handleDateClick = (newDate: Value) => {
     if (newDate instanceof Date) {
       setActiveStartDate(newDate);
       const formattedDate = format(newDate as Date, "yyyy-MM-dd");
@@ -31,35 +33,45 @@ export const Calendar = () => {
     setActiveStartDate(today);
   };
 
-  const handleExpand = () => {
-    setView("month");
+  const toggleExpanded = () => setExpanded((prev) => !prev);
+
+  const handleMonthSelect = (value: Value) => {
+    if (value instanceof Date) {
+      setActiveStartDate(value);
+      setShowMonthSelector(false);
+    }
   };
 
-  const handleCollapse = () => {
-    setView("week");
+  const handleCloseMonthSelector = () => {
+    setShowMonthSelector(false);
   };
 
-  const monthlyData = {
+  const calendarData = {
     today,
-    handleDateChange,
-    handleTodayClick,
+    onDateClick: handleDateClick,
+    onTodayClick: handleTodayClick,
     activeStartDate,
-    setActiveStartDate
+    onActiveStartDateChange: setActiveStartDate,
+    onShowMonthSelectChange: setShowMonthSelector,
+    headerRef: calendarHeaderRef
   };
 
   return (
     <Box bgColor="white" pt={28} radius="0px 0px 20px 20px">
-      {view === "week" ? (
-        <>
-          <WeeklyCalendar />
-          <button onClick={handleExpand}>펼치기</button>
-        </>
-      ) : (
-        <>
-          <MonthlyCalendar data={monthlyData} />
-          <button onClick={handleCollapse}>접기</button>
-        </>
-      )}
+      {expanded ? <MonthlyCalendar data={calendarData} /> : <WeeklyCalendar data={calendarData} />}
+      <ToggleViewButton type="button" onClick={toggleExpanded} expand={expanded}>
+        {expanded ? "닫기" : "펼쳐보기"}
+        <span>
+          <ArrowDownIcon w={20} h={20} />
+        </span>
+      </ToggleViewButton>
+      <MonthSelector
+        isOpen={showMonthSelector}
+        onClose={handleCloseMonthSelector}
+        activeStartDate={activeStartDate}
+        onSelect={handleMonthSelect}
+        anchorRef={calendarHeaderRef}
+      />
     </Box>
   );
 };

--- a/src/components/Agenda/Calendar/MonthPicker.tsx
+++ b/src/components/Agenda/Calendar/MonthPicker.tsx
@@ -17,19 +17,19 @@ import {
 
 import type { Value } from "react-calendar/dist/cjs/shared/types";
 
-interface MonthSelectorProps {
+interface MonthPickerProps {
   isOpen: boolean;
   onClose: () => void;
-  activeStartDate: Date | null;
-  onSelect: (value: Value) => void;
+  activeDate: Date | null;
+  onMonthClick: (value: Value) => void;
   anchorRef: React.RefObject<HTMLDivElement>;
 }
 
-export const MonthSelector: React.FC<MonthSelectorProps> = ({
+export const MonthPicker: React.FC<MonthPickerProps> = ({
   isOpen,
   onClose,
-  activeStartDate,
-  onSelect,
+  activeDate,
+  onMonthClick,
   anchorRef
 }) => {
   const popupRef = useRef<HTMLDivElement>(null);
@@ -41,6 +41,7 @@ export const MonthSelector: React.FC<MonthSelectorProps> = ({
   });
 
   useEffect(() => {
+    // MonthPicker가 캘린더 타이틀 위치에 정확히 위치하도록 설정
     if (isOpen && popupRef.current && anchorRef.current) {
       const calendarNavigation = anchorRef.current;
       const popupNavigation = popupRef.current.querySelector(".react-calendar__navigation");
@@ -68,8 +69,8 @@ export const MonthSelector: React.FC<MonthSelectorProps> = ({
         <PopupWrapper ref={popupRef}>
           <StyledYearView>
             <Calendar
-              value={activeStartDate}
-              onChange={onSelect}
+              value={activeDate}
+              onChange={onMonthClick}
               view="year"
               maxDetail="year"
               minDetail="month"

--- a/src/components/Agenda/Calendar/MonthSelector.tsx
+++ b/src/components/Agenda/Calendar/MonthSelector.tsx
@@ -1,0 +1,92 @@
+import ArrowLeftIcon from "assets/svg/arrow-left-icon";
+import ArrowRightIcon from "assets/svg/arrow-right-icon";
+import XIcon from "assets/svg/x-icon";
+import { FloatingOverlay } from "components/common/FloatingOverlay";
+import { format } from "date-fns";
+import { useClickOutSide } from "hooks/common/useClickOutSide";
+import React, { useEffect, useRef } from "react";
+import Calendar from "react-calendar";
+
+import {
+  PopupContainer,
+  PopupWrapper,
+  StyledYearView,
+  ControlWrapper,
+  ControlButton
+} from "./styles";
+
+import type { Value } from "react-calendar/dist/cjs/shared/types";
+
+interface MonthSelectorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activeStartDate: Date | null;
+  onSelect: (value: Value) => void;
+  anchorRef: React.RefObject<HTMLDivElement>;
+}
+
+export const MonthSelector: React.FC<MonthSelectorProps> = ({
+  isOpen,
+  onClose,
+  activeStartDate,
+  onSelect,
+  anchorRef
+}) => {
+  const popupRef = useRef<HTMLDivElement>(null);
+
+  useClickOutSide({
+    enabled: isOpen,
+    targetRef: popupRef,
+    onClickOutside: onClose
+  });
+
+  useEffect(() => {
+    if (isOpen && popupRef.current && anchorRef.current) {
+      const calendarNavigation = anchorRef.current;
+      const popupNavigation = popupRef.current.querySelector(".react-calendar__navigation");
+
+      if (calendarNavigation && popupNavigation) {
+        const calendarRect = calendarNavigation.getBoundingClientRect();
+        const popupRect = popupRef.current.getBoundingClientRect();
+
+        const topOffset = calendarRect.top - popupRect.top;
+
+        const popupStyle = getComputedStyle(popupRef.current);
+        const paddingTop = parseFloat(popupStyle.paddingTop);
+
+        popupRef.current.style.transform = `translateY(${topOffset - paddingTop}px)`;
+      }
+    }
+  }, [isOpen, anchorRef]);
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <FloatingOverlay type="none" />
+      <PopupContainer>
+        <PopupWrapper ref={popupRef}>
+          <StyledYearView>
+            <Calendar
+              value={activeStartDate}
+              onChange={onSelect}
+              view="year"
+              maxDetail="year"
+              minDetail="month"
+              formatYear={(locale, date) => format(date, "yyyy")}
+              prevLabel={<ArrowLeftIcon w={20} colorScheme="darkBlack" />}
+              nextLabel={<ArrowRightIcon w={20} colorScheme="darkBlack" />}
+              prev2Label={null}
+              next2Label={null}
+            />
+          </StyledYearView>
+          <ControlWrapper>
+            <ControlButton type="button" onClick={onClose}>
+              <XIcon />
+            </ControlButton>
+          </ControlWrapper>
+        </PopupWrapper>
+      </PopupContainer>
+    </>
+  );
+};

--- a/src/components/Agenda/Calendar/MonthlyCalendar.tsx
+++ b/src/components/Agenda/Calendar/MonthlyCalendar.tsx
@@ -13,69 +13,64 @@ import type { Value } from "react-calendar/dist/cjs/shared/types";
 const ATTEND_DAYS = ["2024-07-17", "2024-07-17", "2024-07-21", "2024-07-23"];
 
 interface MonthlyCalendarProps {
-  data: {
-    today: Date;
-    onDateClick: (newDate: Value) => void;
-    onTodayClick: () => void;
-    activeStartDate: Date | null;
-    onActiveStartDateChange: React.Dispatch<React.SetStateAction<Date | null>>;
-    onShowMonthSelectChange: React.Dispatch<React.SetStateAction<boolean>>;
-    headerRef: React.RefObject<HTMLDivElement>;
-  };
+  today: Date;
+  onDateClick: (newDate: Value) => void;
+  onTodayClick: () => void;
+  activeDate: Date | null;
+  onActiveDateChange: React.Dispatch<React.SetStateAction<Date | null>>;
+  onOpenMonthPicker: () => void;
+  headerRef: React.RefObject<HTMLDivElement>;
 }
 
-export const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({ data }) => {
+/* -------------------------------------------------------------------------------------------------
+ * MonthTile
+ * -----------------------------------------------------------------------------------------------*/
+
+const TileContent = ({ date, view, today }: { date: Date; view: string; today: Date }) => {
+  if (view !== "month") return null;
+
+  return (
+    <>
+      {isSameDay(date, today) && (
+        <Text typo="caption1_12_R" color="primaryColor">
+          오늘
+        </Text>
+      )}
+      {ATTEND_DAYS.some((day) => isSameDay(new Date(day), date)) && (
+        <Box as="span" color="br_3">
+          <FootIcon w={15} h={12} />
+        </Box>
+      )}
+    </>
+  );
+};
+
+/* -------------------------------------------------------------------------------------------------
+ * Monthly Calendar
+ * -----------------------------------------------------------------------------------------------*/
+
+export const MonthlyCalendar = (props: MonthlyCalendarProps) => {
   const {
     today,
-    activeStartDate,
+    activeDate,
     onDateClick,
     onTodayClick,
-    onActiveStartDateChange,
-    onShowMonthSelectChange,
+    onActiveDateChange,
+    onOpenMonthPicker,
     headerRef: calendarRef
-  } = data;
+  } = props;
 
   const todayButtonRef = useRef<HTMLButtonElement>(null);
 
-  const handleDrillUp = useCallback(() => {
-    onShowMonthSelectChange(true);
-  }, [onShowMonthSelectChange]);
-
-  const handleActiveStartDateChange = useCallback(
-    ({ view, activeStartDate }: OnArgs) => {
-      if (view === "month") {
-        onActiveStartDateChange(activeStartDate);
-      }
-    },
-    [onActiveStartDateChange]
-  );
-
-  const renderTileContent = useCallback(
-    ({ date, view }: { date: Date; view: string }) => {
-      const contents = [];
-
-      if (view === "month" && isSameDay(date, today)) {
-        contents.push(
-          <Text key="today" typo="caption1_12_R" color="primaryColor">
-            오늘
-          </Text>
-        );
-      }
-
-      if (ATTEND_DAYS.some((day) => isSameDay(new Date(day), date))) {
-        contents.push(
-          <Box key="footIcon" as="span" color="br_3">
-            <FootIcon w={15} h={12} />
-          </Box>
-        );
-      }
-
-      return contents;
-    },
-    [today]
-  );
+  const handleActiveDateChange = ({ view, activeStartDate }: OnArgs) => {
+    // month가 변경될 때 activeDate를 변경
+    if (view === "month") {
+      onActiveDateChange(activeStartDate);
+    }
+  };
 
   const adjustTodayButtonPosition = useCallback(() => {
+    // "오늘" 버튼을 캘린더 타이틀 위치에 정확히 위치하도록 설정
     if (calendarRef.current && todayButtonRef.current) {
       const calendarNavigation = calendarRef.current.querySelector(".react-calendar__navigation");
       const todayButton = todayButtonRef.current;
@@ -103,10 +98,10 @@ export const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({ data }) => {
   return (
     <StyledMonthlyCalendar ref={calendarRef}>
       <Calendar
-        value={activeStartDate}
+        value={activeDate}
         onChange={onDateClick}
-        activeStartDate={activeStartDate || undefined}
-        onActiveStartDateChange={handleActiveStartDateChange}
+        activeStartDate={activeDate || undefined}
+        onActiveStartDateChange={handleActiveDateChange}
         formatDay={(locale, date) => format(date, "d")}
         formatWeekday={(locale, date) => format(date, "E")}
         formatMonthYear={(locale, date) => format(date, "yyyy. MM")}
@@ -119,8 +114,8 @@ export const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({ data }) => {
         prev2Label={null}
         minDetail="year"
         view="month"
-        onDrillUp={handleDrillUp}
-        tileContent={renderTileContent}
+        onDrillUp={onOpenMonthPicker}
+        tileContent={({ date, view }) => <TileContent date={date} view={view} today={today} />}
       />
       <GoToTodayButton type="button" ref={todayButtonRef} onClick={onTodayClick}>
         오늘

--- a/src/components/Agenda/Calendar/MonthlyCalendar.tsx
+++ b/src/components/Agenda/Calendar/MonthlyCalendar.tsx
@@ -1,127 +1,53 @@
 import ArrowLeftIcon from "assets/svg/arrow-left-icon";
 import ArrowRightIcon from "assets/svg/arrow-right-icon";
 import FootIcon from "assets/svg/foot-icon";
-import XIcon from "assets/svg/x-icon";
 import { Box, Text } from "components/common";
-import { FloatingOverlay } from "components/common/FloatingOverlay";
 import { format, isSameDay } from "date-fns";
-import { useClickOutSide } from "hooks/common/useClickOutSide";
-import React, {
-  type ForwardedRef,
-  type RefObject,
-  forwardRef,
-  useCallback,
-  useEffect,
-  useRef,
-  useState
-} from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import Calendar, { type OnArgs } from "react-calendar";
 
-import {
-  StyledMonthlyCalendar,
-  StyledDate,
-  StyledYearView,
-  PopupContainer,
-  ControlWrapper,
-  ControlButton,
-  PopupWrapper
-} from "./styles";
+import { StyledMonthlyCalendar, GoToTodayButton } from "./styles";
 
-type ValuePiece = Date | null;
-type Value = ValuePiece | [ValuePiece, ValuePiece];
+import type { Value } from "react-calendar/dist/cjs/shared/types";
 
-interface YearPopupProps {
-  isOpen: boolean;
-  close: () => void;
-  activeStartDate: Date | null;
-  onSelect: (value: Value) => void;
-}
-
-const YearPopup = forwardRef(function YearPopup(
-  { isOpen, close, activeStartDate, onSelect }: YearPopupProps,
-  ref: ForwardedRef<HTMLDivElement>
-) {
-  const popupRef = ref as RefObject<HTMLDivElement>;
-
-  useClickOutSide({
-    enabled: isOpen,
-    targetRef: popupRef,
-    onClickOutside: close
-  });
-
-  if (!isOpen) return null;
-
-  return (
-    <>
-      <FloatingOverlay type="none" />
-      <PopupContainer>
-        <PopupWrapper ref={ref}>
-          <StyledYearView>
-            <Calendar
-              value={activeStartDate}
-              onChange={onSelect}
-              view="year"
-              maxDetail="year"
-              minDetail="month"
-              formatYear={(locale, date) => format(date, "yyyy")}
-              prevLabel={<ArrowLeftIcon w={20} colorScheme="darkBlack" />}
-              nextLabel={<ArrowRightIcon w={20} colorScheme="darkBlack" />}
-              prev2Label={null}
-              next2Label={null}
-            />
-          </StyledYearView>
-          <ControlWrapper>
-            <ControlButton type="button" onClick={close}>
-              <XIcon />
-            </ControlButton>
-          </ControlWrapper>
-        </PopupWrapper>
-      </PopupContainer>
-    </>
-  );
-});
+const ATTEND_DAYS = ["2024-07-17", "2024-07-17", "2024-07-21", "2024-07-23"];
 
 interface MonthlyCalendarProps {
   data: {
     today: Date;
+    onDateClick: (newDate: Value) => void;
+    onTodayClick: () => void;
     activeStartDate: Date | null;
-    handleDateChange: (newDate: Value) => void;
-    handleTodayClick: () => void;
-    setActiveStartDate: React.Dispatch<React.SetStateAction<Date | null>>;
+    onActiveStartDateChange: React.Dispatch<React.SetStateAction<Date | null>>;
+    onShowMonthSelectChange: React.Dispatch<React.SetStateAction<boolean>>;
+    headerRef: React.RefObject<HTMLDivElement>;
   };
 }
 
-export const MonthlyCalendar = ({ data }: MonthlyCalendarProps) => {
-  const [showYearPopup, setShowYearPopup] = useState(false);
-  const calendarRef = useRef<HTMLDivElement>(null);
-  const popupRef = useRef<HTMLDivElement>(null);
-  const todayRef = useRef<HTMLButtonElement>(null);
+export const MonthlyCalendar: React.FC<MonthlyCalendarProps> = ({ data }) => {
+  const {
+    today,
+    activeStartDate,
+    onDateClick,
+    onTodayClick,
+    onActiveStartDateChange,
+    onShowMonthSelectChange,
+    headerRef: calendarRef
+  } = data;
 
-  const { today, activeStartDate, handleDateChange, handleTodayClick, setActiveStartDate } = data;
-
-  const ATTEND_DAYS = ["2024-07-17", "2024-07-17", "2024-07-21", "2024-07-23"];
+  const todayButtonRef = useRef<HTMLButtonElement>(null);
 
   const handleDrillUp = useCallback(() => {
-    setShowYearPopup(true);
-  }, []);
+    onShowMonthSelectChange(true);
+  }, [onShowMonthSelectChange]);
 
   const handleActiveStartDateChange = useCallback(
     ({ view, activeStartDate }: OnArgs) => {
       if (view === "month") {
-        setActiveStartDate(activeStartDate);
+        onActiveStartDateChange(activeStartDate);
       }
     },
-    [setActiveStartDate]
-  );
-
-  const handleYearSelect = useCallback(
-    (value: Value) => {
-      if (value instanceof Date) {
-        setActiveStartDate(value);
-        setShowYearPopup(false);
-      }
-    },
-    [setActiveStartDate]
+    [onActiveStartDateChange]
   );
 
   const renderTileContent = useCallback(
@@ -130,7 +56,7 @@ export const MonthlyCalendar = ({ data }: MonthlyCalendarProps) => {
 
       if (view === "month" && isSameDay(date, today)) {
         contents.push(
-          <Text typo="caption1_12_R" color="primaryColor" key="today">
+          <Text key="today" typo="caption1_12_R" color="primaryColor">
             오늘
           </Text>
         );
@@ -138,7 +64,7 @@ export const MonthlyCalendar = ({ data }: MonthlyCalendarProps) => {
 
       if (ATTEND_DAYS.some((day) => isSameDay(new Date(day), date))) {
         contents.push(
-          <Box as="span" color="br_3" key="footIcon">
+          <Box key="footIcon" as="span" color="br_3">
             <FootIcon w={15} h={12} />
           </Box>
         );
@@ -150,9 +76,9 @@ export const MonthlyCalendar = ({ data }: MonthlyCalendarProps) => {
   );
 
   const adjustTodayButtonPosition = useCallback(() => {
-    if (calendarRef.current && todayRef.current) {
+    if (calendarRef.current && todayButtonRef.current) {
       const calendarNavigation = calendarRef.current.querySelector(".react-calendar__navigation");
-      const todayButton = todayRef.current;
+      const todayButton = todayButtonRef.current;
 
       if (calendarNavigation) {
         const navRect = calendarNavigation.getBoundingClientRect();
@@ -174,61 +100,31 @@ export const MonthlyCalendar = ({ data }: MonthlyCalendarProps) => {
     };
   }, [adjustTodayButtonPosition]);
 
-  useEffect(() => {
-    if (showYearPopup && calendarRef.current && popupRef.current) {
-      const calendarNavigation = calendarRef.current.querySelector(".react-calendar__navigation");
-      const popupNavigation = popupRef.current.querySelector(".react-calendar__navigation");
-
-      if (calendarNavigation && popupNavigation) {
-        const calendarRect = calendarNavigation.getBoundingClientRect();
-        const popupRect = popupRef.current.getBoundingClientRect();
-
-        const topOffset = calendarRect.top - popupRect.top;
-
-        const popupStyle = getComputedStyle(popupRef.current);
-        const paddingTop = parseFloat(popupStyle.paddingTop);
-
-        popupRef.current.style.transform = `translateY(${topOffset - paddingTop}px)`;
-      }
-    }
-  }, [showYearPopup]);
-
   return (
-    <>
-      <StyledMonthlyCalendar ref={calendarRef}>
-        <Calendar
-          value={activeStartDate}
-          onChange={handleDateChange}
-          activeStartDate={activeStartDate || undefined}
-          onActiveStartDateChange={handleActiveStartDateChange}
-          formatDay={(locale, date) => format(date, "d")}
-          formatWeekday={(locale, date) => format(date, "E")}
-          formatMonthYear={(locale, date) => format(date, "yyyy. MM")}
-          formatYear={(locale, date) => format(date, "yyyy")}
-          calendarType="gregory"
-          showNeighboringMonth={true}
-          prevLabel={<ArrowLeftIcon w={24} colorScheme="darkBlack" />}
-          nextLabel={<ArrowRightIcon w={24} colorScheme="darkBlack" />}
-          next2Label={null}
-          prev2Label={null}
-          minDetail="year"
-          view="month"
-          onDrillUp={handleDrillUp}
-          tileContent={renderTileContent}
-        />
-        <StyledDate type="button" ref={todayRef} onClick={handleTodayClick}>
-          오늘
-        </StyledDate>
-      </StyledMonthlyCalendar>
-      {showYearPopup && (
-        <YearPopup
-          ref={popupRef}
-          isOpen={showYearPopup}
-          close={() => setShowYearPopup(false)}
-          activeStartDate={activeStartDate}
-          onSelect={handleYearSelect}
-        />
-      )}
-    </>
+    <StyledMonthlyCalendar ref={calendarRef}>
+      <Calendar
+        value={activeStartDate}
+        onChange={onDateClick}
+        activeStartDate={activeStartDate || undefined}
+        onActiveStartDateChange={handleActiveStartDateChange}
+        formatDay={(locale, date) => format(date, "d")}
+        formatWeekday={(locale, date) => format(date, "E")}
+        formatMonthYear={(locale, date) => format(date, "yyyy. MM")}
+        formatYear={(locale, date) => format(date, "yyyy")}
+        calendarType="gregory"
+        showNeighboringMonth={true}
+        prevLabel={<ArrowLeftIcon w={24} colorScheme="darkBlack" />}
+        nextLabel={<ArrowRightIcon w={24} colorScheme="darkBlack" />}
+        next2Label={null}
+        prev2Label={null}
+        minDetail="year"
+        view="month"
+        onDrillUp={handleDrillUp}
+        tileContent={renderTileContent}
+      />
+      <GoToTodayButton type="button" ref={todayButtonRef} onClick={onTodayClick}>
+        오늘
+      </GoToTodayButton>
+    </StyledMonthlyCalendar>
   );
 };

--- a/src/components/Agenda/Calendar/WeeklyCalendar.tsx
+++ b/src/components/Agenda/Calendar/WeeklyCalendar.tsx
@@ -1,38 +1,176 @@
-type ValuePiece = Date | null;
-type Value = ValuePiece | [ValuePiece, ValuePiece];
+import ArrowDownIcon from "assets/svg/arrow-down-icon";
+import FootIcon from "assets/svg/foot-icon";
+import { Box, Text } from "components/common";
+import { isSameDay, isBefore, format, isToday, parseISO } from "date-fns";
+import { ko } from "date-fns/locale";
+import { AnimatePresence, motion } from "framer-motion";
+import React, { useEffect, useRef } from "react";
 
-const getWeekRange = (date: string | number | Date) => {
-  const start = new Date(date);
-  start.setDate(start.getDate() - start.getDay());
-  const end = new Date(start);
-  end.setDate(end.getDate() + 6);
+import {
+  DayTile,
+  DayContent,
+  GoToTodayButton,
+  NavigationButton,
+  StyledWeeklyCalendar,
+  StyledWeeklyTitle,
+  WeekContainer
+} from "./styles";
+import { useWeekSwipe } from "./useWeekSwipe";
 
-  const days = [];
-  for (let day = new Date(start); day <= end; day.setDate(day.getDate() + 1)) {
-    days.push(new Date(day));
-  }
-  return days;
-};
+import type { Value } from "react-calendar/dist/cjs/shared/types";
 
-export const WeeklyCalendar = () => {
-  const today = new Date();
-  const weekRange = getWeekRange(today);
-  const weekDays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const RECORD_DATE = ["2024-06-30", "2024-07-17", "2024-07-21", "2024-07-24", "2024-07-25"].map(
+  (d) => parseISO(d)
+);
+const USER_JOIN_DATE = parseISO("2024-02-15");
+
+interface WeeklyCalendarProps {
+  data: {
+    today: Date;
+    onDateClick: (newDate: Value) => void;
+    onTodayClick: () => void;
+    activeStartDate: Date | null;
+    onActiveStartDateChange: React.Dispatch<React.SetStateAction<Date | null>>;
+    onShowMonthSelectChange: React.Dispatch<React.SetStateAction<boolean>>;
+    headerRef: React.RefObject<HTMLDivElement>;
+  };
+}
+
+interface WeekViewProps {
+  week: Date[];
+  activeStartDate: Date;
+  isDateDisabled: (date: Date) => boolean;
+  onDateClick: (date: Date) => void;
+  weekDays: string[];
+  isActive: boolean;
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * WeekView
+ * -----------------------------------------------------------------------------------------------*/
+
+const WeekView = ({
+  week,
+  activeStartDate,
+  isDateDisabled,
+  onDateClick,
+  weekDays,
+  isActive
+}: WeekViewProps) => (
+  <WeekContainer active={isActive}>
+    {week.map((day) => (
+      <DayTile
+        key={day.toISOString()}
+        type="button"
+        aria-label={format(day, "yyyy년 M월 d일", { locale: ko })}
+        className={`
+          ${isSameDay(day, activeStartDate) ? "active" : ""}
+          ${isDateDisabled(day) ? "disabled" : ""}
+          ${!isActive ? "neighboring-week" : ""}
+        `.trim()}
+        onClick={() => onDateClick(day)}
+        disabled={isDateDisabled(day)}
+      >
+        <Text
+          as="abbr"
+          title={`${weekDays[day.getDay()]}`}
+          typo="label2_14_M"
+          color="inherit"
+          textDecoration="none"
+          className={day.getDay() === 0 ? "weekday sunday" : "weekday"}
+        >
+          {weekDays[day.getDay()]}
+        </Text>
+        <DayContent>
+          <abbr title={format(day, "yyyy년 M월 d일", { locale: ko })} className="day">
+            {format(day, "d")}
+          </abbr>
+          {isToday(day) && <p className="today">오늘</p>}
+          {RECORD_DATE.some((date) => isSameDay(date, day)) && (
+            <Box as="span" color="br_3" key="footIcon">
+              <FootIcon w={15} h={12} />
+            </Box>
+          )}
+        </DayContent>
+      </DayTile>
+    ))}
+  </WeekContainer>
+);
+
+/* -------------------------------------------------------------------------------------------------
+ * WeeklyCalendar
+ * -----------------------------------------------------------------------------------------------*/
+
+export const WeeklyCalendar = ({ data }: WeeklyCalendarProps) => {
+  const {
+    today,
+    onDateClick,
+    onTodayClick,
+    activeStartDate,
+    onActiveStartDateChange,
+    onShowMonthSelectChange,
+    headerRef
+  } = data;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const containerWidth = containerRef.current?.offsetWidth || 0;
+
+  const isDateDisabled = (date: Date) => {
+    return isBefore(date, USER_JOIN_DATE);
+  };
+
+  const { weeks, controls, handleDragEnd, generateWeeks, setWeeks, isDateSelectable } =
+    useWeekSwipe(containerWidth, activeStartDate, onActiveStartDateChange, isDateDisabled, today);
+
+  useEffect(() => {
+    if (activeStartDate) {
+      setWeeks(generateWeeks(activeStartDate));
+      controls.set({ x: -containerWidth });
+    }
+  }, [activeStartDate, generateWeeks, controls, setWeeks, containerWidth]);
+
+  const weekDays = ["일", "월", "화", "수", "목", "금", "토"];
+
+  if (!activeStartDate) return null;
 
   return (
-    <div className="weekly-calendar">
-      <div className="week-header">
-        {weekDays.map((day) => (
-          <div key={day}>{day}</div>
-        ))}
-      </div>
-      <div className="week-days">
-        {weekRange.map((day) => (
-          <div key={day.toISOString()} className="day-tile">
-            {day.getDate()}
-          </div>
-        ))}
-      </div>
-    </div>
+    <>
+      <StyledWeeklyTitle ref={headerRef}>
+        <Text typo="label1_16_B" color="primaryColor">
+          {format(activeStartDate, "yyyy. MM", { locale: ko })}
+        </Text>
+        <NavigationButton type="button" onClick={() => onShowMonthSelectChange(true)}>
+          <ArrowDownIcon w={20} h={20} />
+        </NavigationButton>
+        <GoToTodayButton type="button" onClick={onTodayClick}>
+          오늘
+        </GoToTodayButton>
+      </StyledWeeklyTitle>
+      <StyledWeeklyCalendar ref={containerRef}>
+        <AnimatePresence>
+          <motion.div
+            drag="x"
+            dragConstraints={{ left: -containerWidth * 2, right: 0 }}
+            onDragEnd={handleDragEnd}
+            animate={controls}
+            initial={{ x: -containerWidth }}
+            dragTransition={{ bounceStiffness: 600, bounceDamping: 20 }}
+            style={{ display: "flex" }}
+          >
+            {weeks.map((week, weekIndex) => (
+              <WeekView
+                key={weekIndex}
+                week={week}
+                activeStartDate={activeStartDate}
+                isDateDisabled={(date) => !isDateSelectable(date)}
+                onDateClick={onDateClick}
+                weekDays={weekDays}
+                isActive={weekIndex === 1}
+              />
+            ))}
+          </motion.div>
+        </AnimatePresence>
+      </StyledWeeklyCalendar>
+    </>
   );
 };

--- a/src/components/Agenda/Calendar/styles.ts
+++ b/src/components/Agenda/Calendar/styles.ts
@@ -255,13 +255,19 @@ export const WeekContainer = styled.div.withConfig({
   transition: opacity 0.3s ease;
 `;
 
-export const StyledWeeklyTitle = styled.div`
+export const StyledWeeklyHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+
   margin-bottom: ${remCalc(14)};
   height: 44px;
+`;
+
+export const StyledWeeklyTitle = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
 `;
 
 export const NavigationButton = styled.button`

--- a/src/components/Agenda/Calendar/styles.ts
+++ b/src/components/Agenda/Calendar/styles.ts
@@ -12,13 +12,13 @@ export const StyledMonthlyCalendar = styled.div`
   .react-calendar {
     width: 100%;
     border: none;
-    padding-bottom: ${remCalc(14)};
   }
 
   /* Navigation Styling */
   .react-calendar__navigation {
     justify-content: center;
     gap: 10px;
+    margin-bottom: ${remCalc(14)};
 
     button:enabled:hover,
     button:enabled:focus,
@@ -109,26 +109,6 @@ export const StyledMonthlyCalendar = styled.div`
       }
     }
   }
-`;
-
-// Styled Date Button
-export const StyledDate = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  max-width: 52px;
-  width: 100%;
-  height: 24px;
-  position: absolute;
-  right: 36px;
-  font-size: 0.8rem;
-  letter-spacing: 0.015rem;
-  line-height: 1.25rem;
-  font-weight: 800;
-  font-family: "Pretendard Variable";
-  background-color: ${({ theme }) => theme.colors.primary_2};
-  color: ${({ theme }) => theme.colors.yellow_3};
-  border-radius: 15px;
 `;
 
 // Popup Container
@@ -231,4 +211,155 @@ export const ControlWrapper = styled.div`
 // Control Button
 export const ControlButton = styled.button`
   color: ${({ theme }) => theme.colors.gray_2};
+`;
+
+// Go to Today Button
+export const GoToTodayButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  max-width: 52px;
+  width: 100%;
+  height: 24px;
+
+  position: absolute;
+  right: 36px;
+
+  font-size: 0.8rem;
+  letter-spacing: 0.015rem;
+  line-height: 1.25rem;
+  font-weight: 800;
+  font-family: "Pretendard Variable";
+
+  background-color: ${({ theme }) => theme.colors.primary_2};
+  color: ${({ theme }) => theme.colors.yellow_3};
+  border-radius: 15px;
+`;
+
+// Styled Weekly Calendar
+export const StyledWeeklyCalendar = styled.div`
+  width: calc(100% - 16px);
+  overflow: hidden;
+  margin: 0 auto;
+  margin-block-end: 12px;
+`;
+
+export const WeekContainer = styled.div.withConfig({
+  shouldForwardProp: (prop) => !["active"].includes(prop)
+})<{ active: boolean }>`
+  display: flex;
+  width: 100%;
+  flex-shrink: 0;
+  opacity: ${(props) => (props.active ? 1 : 0.3)};
+  transition: opacity 0.3s ease;
+`;
+
+export const StyledWeeklyTitle = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: ${remCalc(14)};
+  height: 44px;
+`;
+
+export const NavigationButton = styled.button`
+  width: 20px;
+  height: 20px;
+  color: ${({ theme }) => theme.colors.primaryColor};
+  background-color: ${({ theme }) => theme.colors.yellow_3};
+  border-radius: 50%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const DayTile = styled.button`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 0 0 calc(100% / 7);
+  scroll-snap-align: start;
+
+  min-height: 64px;
+  max-height: 64px;
+  height: 100%;
+
+  padding-inline: 13px;
+  border-radius: 12px;
+  color: ${({ theme }) => theme.colors.gray_3};
+  font-family: inherit;
+
+  &.active {
+    background-color: ${({ theme }) => theme.colors.yellow_3};
+    scroll-snap-align: center;
+  }
+
+  &.active .day {
+    color: ${({ theme }) => theme.colors.primaryColor};
+  }
+
+  &.active .weekday {
+    color: ${({ theme }) => theme.colors.br_2};
+  }
+
+  &.active .weekday.sunday {
+    color: ${({ theme }) => theme.colors.red_1};
+  }
+
+  &.disabled {
+    color: ${({ theme }) => theme.colors.gray_4};
+  }
+
+  &.neighboring-week {
+    pointer-events: none;
+  }
+`;
+
+export const DayContent = styled.span`
+  white-space: nowrap;
+  display: flex;
+  flex-direction: column;
+
+  & > abbr.day {
+    ${({ theme }) => theme.typo.body2_16_B};
+    color: inherit;
+    text-decoration: none;
+    line-height: normal;
+  }
+
+  & > .today {
+    color: ${({ theme }) => theme.colors.br_2};
+    ${({ theme }) => theme.typo.caption1_12_R};
+    line-height: normal;
+  }
+`;
+
+// 캘린더 뷰 토글 버튼
+export const ToggleViewButton = styled.button.withConfig({
+  shouldForwardProp: (prop) => !["expand"].includes(prop)
+})<{ expand?: boolean }>`
+  padding-block: ${remCalc(14)};
+  color: ${({ theme }) => theme.colors.gray_1};
+  ${({ theme }) => theme.typo.label2_14_M};
+
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+
+  & > span {
+    display: flex;
+    align-items: center;
+  }
+
+  & > span > svg {
+    transform: ${({ expand }) => (expand ? "rotate(180deg)" : "rotate(0deg)")};
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 0.15s;
+  }
 `;

--- a/src/components/Agenda/Calendar/useWeekSwipe.ts
+++ b/src/components/Agenda/Calendar/useWeekSwipe.ts
@@ -1,17 +1,26 @@
-import { addDays, addWeeks, startOfWeek, subWeeks, endOfWeek, isAfter } from "date-fns";
+import { addDays, addWeeks, startOfWeek, subWeeks, endOfWeek, isAfter, isBefore } from "date-fns";
 import { type PanInfo, useAnimation } from "framer-motion";
 import { useCallback, useState } from "react";
 
-export const useWeekSwipe = (
-  containerWidth: number,
-  activeStartDate: Date | null,
-  onActiveStartDateChange: (date: Date) => void,
-  isDateDisabled: (date: Date) => boolean,
-  today: Date
-) => {
+interface UseWeekSwipeProps {
+  containerWidth: number;
+  activeDate: Date | null;
+  onActiveDateChange: (date: Date) => void;
+  today: Date;
+  maxDate: Date;
+}
+
+export const useWeekSwipe = ({
+  containerWidth,
+  activeDate,
+  onActiveDateChange,
+  today,
+  maxDate
+}: UseWeekSwipeProps) => {
   const [weeks, setWeeks] = useState<Date[][]>([]);
   const controls = useAnimation();
 
+  // 주어진 날짜를 기준으로 이전 주, 현재 주, 다음 주의 날짜들을 생성
   const generateWeeks = useCallback((date: Date) => {
     const currentWeekStart = startOfWeek(date, { weekStartsOn: 0 });
     const prevWeekStart = subWeeks(currentWeekStart, 1);
@@ -30,76 +39,57 @@ export const useWeekSwipe = (
     ];
   }, []);
 
-  const isNextWeekDisabled = useCallback(
-    (date: Date) => {
-      const endOfCurrentWeek = endOfWeek(today, { weekStartsOn: 0 });
-      return isAfter(date, endOfCurrentWeek);
-    },
-    [today]
-  );
+  // 다음 주가 선택 가능한지 확인
+  // 오늘 날짜 이후의 주는 선택할 수 없습니다.
+  const isNextWeekDisabled = (date: Date) => {
+    const endOfCurrentWeek = endOfWeek(today, { weekStartsOn: 0 });
+    return isAfter(date, endOfCurrentWeek);
+  };
 
-  const handleDragEnd = useCallback(
-    async (event: MouseEvent | TouchEvent, info: PanInfo) => {
-      if (Math.abs(info.offset.x) > containerWidth / 7 && activeStartDate) {
-        const direction = info.offset.x > 0 ? -1 : 1;
-        const newActiveStartDate =
-          direction > 0 ? addWeeks(activeStartDate, 1) : subWeeks(activeStartDate, 1);
+  // 개별 날짜가 선택 가능한지 확인
+  // 최대 날짜 이전의 날짜만 선택 가능합니다.
+  const isDateDisabled = (date: Date) => isBefore(date, maxDate);
 
-        if (!isNextWeekDisabled(newActiveStartDate) && !isDateDisabled(newActiveStartDate)) {
-          await controls.start({
-            x: -containerWidth - direction * containerWidth,
-            transition: {
-              type: "spring",
-              stiffness: 300,
-              damping: 30,
-              velocity: info.velocity.x
-            }
-          });
-
-          onActiveStartDateChange(newActiveStartDate);
-          setWeeks(generateWeeks(newActiveStartDate));
-          await controls.set({ x: -containerWidth });
-        } else {
-          controls.start({
-            x: -containerWidth,
-            transition: {
-              type: "spring",
-              stiffness: 300,
-              damping: 30,
-              velocity: info.velocity.x
-            }
-          });
-        }
-      } else {
-        controls.start({
-          x: -containerWidth,
-          transition: {
-            type: "spring",
-            stiffness: 300,
-            damping: 30,
-            velocity: info.velocity.x
-          }
-        });
+  const animateSwipe = async (direction: number, info: PanInfo) => {
+    await controls.start({
+      x: -containerWidth - direction * containerWidth,
+      transition: {
+        type: "spring",
+        stiffness: 300,
+        damping: 30,
+        velocity: info.velocity.x
       }
-    },
-    [
-      activeStartDate,
-      containerWidth,
-      controls,
-      generateWeeks,
-      isDateDisabled,
-      isNextWeekDisabled,
-      onActiveStartDateChange
-    ]
-  );
+    });
+  };
 
-  const isDateSelectable = useCallback(
-    (date: Date) => {
-      const endOfCurrentWeek = endOfWeek(today, { weekStartsOn: 0 });
-      return !isDateDisabled(date) && !isAfter(date, endOfCurrentWeek);
-    },
-    [isDateDisabled, today]
-  );
+  const resetPosition = () =>
+    controls.start({
+      x: -containerWidth,
+      transition: { type: "spring", stiffness: 300, damping: 30 }
+    });
+
+  const handleDragEnd = async (event: MouseEvent | TouchEvent, info: PanInfo) => {
+    if (Math.abs(info.offset.x) > containerWidth / 7 && activeDate) {
+      const direction = info.offset.x > 0 ? -1 : 1;
+      const newActiveDate = direction > 0 ? addWeeks(activeDate, 1) : subWeeks(activeDate, 1);
+
+      if (!isNextWeekDisabled(newActiveDate) && !isDateDisabled(newActiveDate)) {
+        await animateSwipe(direction, info);
+        onActiveDateChange(newActiveDate);
+        setWeeks(generateWeeks(newActiveDate));
+        await controls.set({ x: -containerWidth });
+      } else {
+        await resetPosition();
+      }
+    } else {
+      await resetPosition();
+    }
+  };
+
+  const isDateSelectable = (date: Date) => {
+    const endOfCurrentWeek = endOfWeek(today, { weekStartsOn: 0 });
+    return !isDateDisabled(date) && !isAfter(date, endOfCurrentWeek);
+  };
 
   return { weeks, controls, handleDragEnd, generateWeeks, setWeeks, isDateSelectable };
 };

--- a/src/components/Agenda/Calendar/useWeekSwipe.ts
+++ b/src/components/Agenda/Calendar/useWeekSwipe.ts
@@ -1,0 +1,105 @@
+import { addDays, addWeeks, startOfWeek, subWeeks, endOfWeek, isAfter } from "date-fns";
+import { type PanInfo, useAnimation } from "framer-motion";
+import { useCallback, useState } from "react";
+
+export const useWeekSwipe = (
+  containerWidth: number,
+  activeStartDate: Date | null,
+  onActiveStartDateChange: (date: Date) => void,
+  isDateDisabled: (date: Date) => boolean,
+  today: Date
+) => {
+  const [weeks, setWeeks] = useState<Date[][]>([]);
+  const controls = useAnimation();
+
+  const generateWeeks = useCallback((date: Date) => {
+    const currentWeekStart = startOfWeek(date, { weekStartsOn: 0 });
+    const prevWeekStart = subWeeks(currentWeekStart, 1);
+    const nextWeekStart = addWeeks(currentWeekStart, 1);
+
+    const generateWeek = (start: Date) => {
+      return Array(7)
+        .fill(null)
+        .map((_, i) => addDays(start, i));
+    };
+
+    return [
+      generateWeek(prevWeekStart),
+      generateWeek(currentWeekStart),
+      generateWeek(nextWeekStart)
+    ];
+  }, []);
+
+  const isNextWeekDisabled = useCallback(
+    (date: Date) => {
+      const endOfCurrentWeek = endOfWeek(today, { weekStartsOn: 0 });
+      return isAfter(date, endOfCurrentWeek);
+    },
+    [today]
+  );
+
+  const handleDragEnd = useCallback(
+    async (event: MouseEvent | TouchEvent, info: PanInfo) => {
+      if (Math.abs(info.offset.x) > containerWidth / 7 && activeStartDate) {
+        const direction = info.offset.x > 0 ? -1 : 1;
+        const newActiveStartDate =
+          direction > 0 ? addWeeks(activeStartDate, 1) : subWeeks(activeStartDate, 1);
+
+        if (!isNextWeekDisabled(newActiveStartDate) && !isDateDisabled(newActiveStartDate)) {
+          await controls.start({
+            x: -containerWidth - direction * containerWidth,
+            transition: {
+              type: "spring",
+              stiffness: 300,
+              damping: 30,
+              velocity: info.velocity.x
+            }
+          });
+
+          onActiveStartDateChange(newActiveStartDate);
+          setWeeks(generateWeeks(newActiveStartDate));
+          await controls.set({ x: -containerWidth });
+        } else {
+          controls.start({
+            x: -containerWidth,
+            transition: {
+              type: "spring",
+              stiffness: 300,
+              damping: 30,
+              velocity: info.velocity.x
+            }
+          });
+        }
+      } else {
+        controls.start({
+          x: -containerWidth,
+          transition: {
+            type: "spring",
+            stiffness: 300,
+            damping: 30,
+            velocity: info.velocity.x
+          }
+        });
+      }
+    },
+    [
+      activeStartDate,
+      containerWidth,
+      controls,
+      generateWeeks,
+      isDateDisabled,
+      isNextWeekDisabled,
+      onActiveStartDateChange
+    ]
+  );
+
+  const isDateSelectable = useCallback(
+    (date: Date) => {
+      const endOfCurrentWeek = endOfWeek(today, { weekStartsOn: 0 });
+      return !isDateDisabled(date) && !isAfter(date, endOfCurrentWeek);
+    },
+    [isDateDisabled, today]
+  );
+
+  return { weeks, controls, handleDragEnd, generateWeeks, setWeeks, isDateSelectable };
+};

--- a/src/components/common/Box/styles.ts
+++ b/src/components/common/Box/styles.ts
@@ -85,7 +85,8 @@ export const StyledBox = styled.div.withConfig({
       "align",
       "flex",
       "gap",
-      "zIndex"
+      "zIndex",
+      "whiteSpace"
     ].includes(prop)
 })<BoxOptions>`
   ${(props) => getSizeStyle(props)};
@@ -96,6 +97,7 @@ export const StyledBox = styled.div.withConfig({
   ${(props) => getColorStyle(props)};
   ${(props) => getPositionStyle(props)};
 
+  white-space: ${(props) => props.whiteSpace};
   overflow: ${(props) => props.overflow};
   text-align: ${(props) => props.textAlign};
 `;

--- a/src/components/common/Text/index.tsx
+++ b/src/components/common/Text/index.tsx
@@ -11,6 +11,7 @@ export type TextOptions = {
   isEllipsis?: boolean;
   textAlign?: CSSProperties["textAlign"];
   whiteSpace?: CSSProperties["whiteSpace"];
+  textDecoration?: CSSProperties["textDecoration"];
 };
 
 type TextProps<C extends ElementType = "span"> = PolymorphicComponentPropsWithRef<C, TextOptions>;

--- a/src/components/common/Text/styles.ts
+++ b/src/components/common/Text/styles.ts
@@ -5,7 +5,7 @@ import type { TextOptions } from ".";
 export const StyledText = styled.span.withConfig({
   displayName: "Text",
   shouldForwardProp: (prop) =>
-    !["color", "typo", "isEllipsis", "textAlign", "whiteSpace"].includes(prop)
+    !["color", "typo", "isEllipsis", "textAlign", "whiteSpace", "textDecoration"].includes(prop)
 })<TextOptions>`
   color: ${(props) => props.theme.colors[props.color || "darkBlack"]};
   ${(props) => props.theme.typo[props.typo || "body2_16_R"]}
@@ -18,4 +18,5 @@ export const StyledText = styled.span.withConfig({
     `}
   text-align: ${(props) => props.textAlign};
   white-space: ${(props) => props.whiteSpace};
+  text-decoration: ${(props) => props.textDecoration};
 `;

--- a/src/styles/CalendarStyle.ts
+++ b/src/styles/CalendarStyle.ts
@@ -1,0 +1,3 @@
+import "react-calendar/dist/Calendar.css";
+
+// TODO: 캘린더 기본 스타일 전역에서 관리하기.

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -1,5 +1,6 @@
 import { createGlobalStyle } from "styled-components";
 import reset from "styled-reset";
+import "./CalendarStyle";
 
 export const GlobalStyle = createGlobalStyle`
 ${reset}


### PR DESCRIPTION
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
0.0.86.3
주간 캘린더와 스와이프 기능을 구현합니다.

🔗 [기능 명세 & 정책 정리](https://www.notion.so/8bc60a9972464d0baaef5681b6eeb6f2?pvs=4)

## 작업 내용
1. WeeklyCalendar 컴포넌트 구현
   - 오늘 날짜 기준 1주일 표시
   - 선택한 날짜 활성화 표시 (기본값: 오늘)
   - 사진 기록이 있는 날짜에 마커 표시 → 기록 데이터는 하드코딩 처리
   - 사용자 가입 이전 날짜 및 미래 날짜 비활성화
   - 연도와 월 선택 기능 추가
   - '오늘' 버튼 기능 구현
   - 좌우 스와이프로 캘린더 탐색 가능
   - 스와이프 시 현재, 이전, 이후 주간 날짜 표시
   - '펼쳐보기' 기능으로 월간 달력 전환 지원

2. useWeekSwipe 훅 구현
   - framer-motion을 활용한 스와이프 로직 구현
   - 주간 생성 및 관리
   - 날짜 선택 가능 여부 판단
   - 동적 날짜 범위 생성

## 논의할 점
- 활성 날짜 하이라이팅 지연 문제
스와이프 후 새로운 주간으로 이동할 때 새로운 활성날짜에 하이라이팅이 즉시 반영되지 않는 문제가 있습니다. 
 🔗 [자세한 이슈](https://www.notion.so/3d0f287ea8b94cd1a0c30a0b7d89bcbb?pvs=4)

## 스크린샷
https://github.com/user-attachments/assets/cf58d8dc-335c-491f-98dd-6941d7f82cca

@seongnam95 @hyerani @jieun419 