### PR TITLE
Feat: 어댑터 패턴 적용 및 날짜 관련 개선사항 추가

### DIFF
--- a/src/apis/admin/attendance.api.ts
+++ b/src/apis/admin/attendance.api.ts
@@ -1,4 +1,3 @@
-import { format } from "date-fns";
 import authAxios from "libs/AuthAxios";
 import { request } from "libs/AuthAxios/request";
 
@@ -124,40 +123,50 @@ export const handleGetDogDetail = async (dogId: number) => {
   return data;
 };
 
-// 강아지 상세 - 메모 수정
-export const handlePostDogMemo = async (dogId: number, memo: string): Promise<void> => {
+/**
+ * GET v0/admin/attendance/dog/info/memo (메모 등록)
+ */
+export const handlePostDogMemo = async (req: { dogId: number; memo: string }): Promise<void> => {
   const url = `admin/attendance/dog/info/memo`;
   const { data } = await authAxios.post(url, {
-    dogId,
-    memo
+    dogId: req.dogId,
+    memo: req.memo
   });
   return data;
 };
 
-// 강아지 상세 - 등원 기록
-export const handleGetDogInfoRecord = async (dogId: number, date?: string) => {
+/**
+ * GET v0/admin/attendance/dog/info/record (등원기록)
+ */
+export const handleGetDogInfoRecord = async (
+  dogId: number,
+  date?: string
+): Promise<DogInfoRecordData[]> => {
   const url = `admin/attendance/dog/info/record`;
-  const { data } = await request<DogInfoRecordData[]>({
-    url,
+  const { data } = await authAxios.get(url, {
     params: {
       dogId,
-      date: date || format(new Date(), "yyyy-MM-dd")
+      date
     }
   });
-  return data;
+  return data.data;
 };
 
-// 강아지 상세 - 알림장
-export const handleGetDogInfoAgenda = async (dogId: number, date?: string) => {
+/**
+ * GET v0/admin/attendance/dog/info/agenda (알림장)
+ */
+export const handleGetDogInfoAgenda = async (
+  dogId: number,
+  date?: string
+): Promise<DogInfoAgendaData> => {
   const url = `admin/attendance/dog/info/agenda`;
-  const { data } = await request<DogInfoAgendaData>({
-    url,
+  const { data } = await authAxios.get(url, {
     params: {
       dogId,
-      date: date || format(new Date(), "yyyy-MM-dd")
+      date
     }
   });
-  return data;
+  return data.data;
 };
 
 // 강아지 상세 - 이용권 정보

--- a/src/components/Admin/DogDetailInfo/NewTicketForm/NewTicketForm.tsx
+++ b/src/components/Admin/DogDetailInfo/NewTicketForm/NewTicketForm.tsx
@@ -5,6 +5,7 @@ import { Flex } from "components/common";
 import DayMultiCheck from "components/common/Select/DayMultiCheck";
 import SelectNumber from "components/common/Select/SelectNumber";
 import SingleRadio from "components/common/Select/SingleRadio";
+import { FIELD_MAPPING } from "libs/adapters";
 import { useFormContext } from "react-hook-form";
 
 import * as S from "./styles";
@@ -16,7 +17,7 @@ interface NewTicketFormProps {
   attendanceDays: string[];
 }
 
-const NewTicketForm = ({ formData, attendanceDays }: NewTicketFormProps) => {
+export function NewTicketForm({ formData, attendanceDays }: NewTicketFormProps) {
   const { watch, setValue } = useFormContext();
 
   const selectedTicketType = watch(FIELD.TICKET_TYPE);
@@ -42,7 +43,7 @@ const NewTicketForm = ({ formData, attendanceDays }: NewTicketFormProps) => {
         <S.Label>이용권 유형</S.Label>
         <SingleRadio name={FIELD.TICKET_TYPE} radiosText={TicketTypeText} />
       </S.Card>
-      {selectedTicketType === "정기권" ? (
+      {selectedTicketType === FIELD_MAPPING["ticketType"].MONTHLY ? (
         <S.Card>
           <S.Label>정기권 유형</S.Label>
           <SingleRadio name={FIELD.MONTHLY_TICKET_NUMBER} radiosText={monthlyTicketText} />
@@ -59,6 +60,4 @@ const NewTicketForm = ({ formData, attendanceDays }: NewTicketFormProps) => {
       </S.Card>
     </Flex>
   );
-};
-
-export default NewTicketForm;
+}

--- a/src/components/Admin/DogDetailInfo/NewTicketForm/SubmitButton.tsx
+++ b/src/components/Admin/DogDetailInfo/NewTicketForm/SubmitButton.tsx
@@ -1,21 +1,33 @@
+import { PATH } from "constants/path";
+
 import { Box } from "components/common";
 import { WideButton } from "components/common/Button/Templates";
 import { useCreateNewTicket } from "hooks/api/admin/ticket";
 import { Adapter, NewTicketFormToServerAdapter } from "libs/adapters";
 import { FieldValues, useFormContext } from "react-hook-form";
+import { useLocation, useNavigate } from "react-router-dom";
 import { NewTicketReq } from "types/admin/attendance.type";
 
 const SubmitButton = ({ dogId }: { dogId: number }) => {
   const { handleSubmit } = useFormContext();
-
   const { mutateNewTicket } = useCreateNewTicket(dogId);
+  const navigate = useNavigate();
+  const { search } = useLocation();
+
+  const handleNavigate = () => {
+    // 쿼리 파라미터를 유지한 채로 이동합니다
+    // /admin/attendance/11?dog_name=%EC%A0%9C%EC%8B%9C%EC%B9%B4&ticket_status=true&tab=ticket
+    const path = `${PATH.ADMIN_ATTENDANCE_INFO(dogId)}${search}`;
+    navigate(path, { replace: true });
+  };
 
   const onSubmit = (data: FieldValues) => {
     const requestData = Adapter.from(data).to<FieldValues, NewTicketReq>((item) =>
       new NewTicketFormToServerAdapter(item).adapt()
     );
-    console.log(requestData);
-    //   mutateNewTicket(requestData);
+    mutateNewTicket(requestData, {
+      onSuccess: () => handleNavigate()
+    });
   };
 
   return (

--- a/src/components/Admin/DogDetailInfo/NewTicketForm/index.ts
+++ b/src/components/Admin/DogDetailInfo/NewTicketForm/index.ts
@@ -1,0 +1,1 @@
+export * from "./NewTicketForm";

--- a/src/libs/adapters/Adapter.ts
+++ b/src/libs/adapters/Adapter.ts
@@ -1,3 +1,4 @@
+import { FIELD_MAPPING, type FieldKey, type BeFieldType, type FeFieldType } from "./adaptor";
 export class Adapter {
   private static value: unknown;
 
@@ -7,7 +8,58 @@ export class Adapter {
   }
 
   static to<Input, Output>(mapperFn: (value: Input) => Output) {
-    const transformed = mapperFn(this.value as Input);
-    return transformed;
+    return mapperFn(this.value as Input);
+  }
+}
+
+export class DataFormatAdapter<T extends Record<string, any>> {
+  constructor(private data: T) {}
+
+  private convertBe2Fe<K extends FieldKey>(field: K, value: BeFieldType<K>): FeFieldType<K> {
+    if (!(field in FIELD_MAPPING) || !(value in FIELD_MAPPING[field])) {
+      throw new Error(`Invalid field or value: field=${field}, value=${String(value)}`);
+    }
+    return FIELD_MAPPING[field][value];
+  }
+
+  private convertFe2Be<K extends FieldKey>(field: K, value: FeFieldType<K>): BeFieldType<K> {
+    if (!(field in FIELD_MAPPING)) {
+      throw new Error(`Invalid field: ${field}`);
+    }
+    const entry = Object.entries(FIELD_MAPPING[field]).find(([, v]) => v === value);
+    if (!entry) {
+      throw new Error(`Invalid frontend value for field ${field}: ${String(value)}`);
+    }
+    return entry[0] as BeFieldType<K>;
+  }
+
+  toFrontend(): { [K in keyof T]: K extends FieldKey ? FeFieldType<K> : T[K] } {
+    const result: Partial<{ [K in keyof T]: K extends FieldKey ? FeFieldType<K> : T[K] }> = {};
+    for (const [key, value] of Object.entries(this.data)) {
+      if (key in FIELD_MAPPING && typeof value === "string") {
+        result[key as keyof T] = this.convertBe2Fe(
+          key as FieldKey,
+          value as BeFieldType<FieldKey>
+        ) as any;
+      } else {
+        result[key as keyof T] = value;
+      }
+    }
+    return result as { [K in keyof T]: K extends FieldKey ? FeFieldType<K> : T[K] };
+  }
+
+  toBackend(): { [K in keyof T]: K extends FieldKey ? BeFieldType<K> : T[K] } {
+    const result: Partial<{ [K in keyof T]: K extends FieldKey ? BeFieldType<K> : T[K] }> = {};
+    for (const [key, value] of Object.entries(this.data)) {
+      if (key in FIELD_MAPPING && typeof value === "string") {
+        result[key as keyof T] = this.convertFe2Be(
+          key as FieldKey,
+          value as FeFieldType<FieldKey>
+        ) as any;
+      } else {
+        result[key as keyof T] = value;
+      }
+    }
+    return result as { [K in keyof T]: K extends FieldKey ? BeFieldType<K> : T[K] };
   }
 }

--- a/src/libs/adapters/ServerToFormAdapter.ts
+++ b/src/libs/adapters/ServerToFormAdapter.ts
@@ -7,6 +7,7 @@ import {
 } from "constants/field";
 
 import { NewTicketData, TicketDetailData } from "types/admin/attendance.type";
+import { padToTwoDigits } from "utils/date";
 import { getLabelForValue } from "utils/formatter";
 
 import type { MemberFormData } from "types/admin/enrollment.types";
@@ -287,20 +288,22 @@ export class TicketDetailFormAdapter extends BaseAdapter<
     monthlyTicketNumber: string;
     roundTicketNumber: string;
     attendanceDays: string[];
-    year: number;
-    month: number;
-    day: number;
+    year: string;
+    month: string;
+    day: string;
   }
 > {
   adapt() {
+    const currentDate = new Date();
+
     return {
       ticketType: this.getFieldLabel(FIELD.TICKET_TYPE),
       monthlyTicketNumber: this.value[FIELD.MONTHLY_TICKET_NUMBER] + "주",
       roundTicketNumber: this.value.allRoundTicket + "회",
       attendanceDays: this.value[FIELD.ATTENDANCE_DAYS] ?? [],
-      year: new Date().getFullYear(),
-      month: new Date().getMonth() + 1,
-      day: new Date().getDate()
+      year: currentDate.getFullYear().toString(),
+      month: padToTwoDigits(currentDate.getMonth() + 1),
+      day: padToTwoDigits(currentDate.getDate())
     };
   }
 }

--- a/src/libs/adapters/adaptor.ts
+++ b/src/libs/adapters/adaptor.ts
@@ -1,0 +1,20 @@
+/**
+ * 필드 매핑을 위한 상수 객체
+ * 각 필드는 백엔드 키와 프론트엔드 값의 쌍으로 구성되어 있습니다.
+ */
+export const FIELD_MAPPING = {
+  memberGender: { MALE: "남", FEMALE: "여" },
+  dogGender: { MALE: "수컷", FEMALE: "암컷" },
+  dogSize: { BIG: "대형견", MEDIUM: "중형견", SMALL: "소형견" },
+  neutralization: { NEUTERED: "했어요", NOT_NEUTERED: "안했어요" },
+  vaccination: { VACCINATED: "했어요", NOT_VACCINATED: "안했어요" },
+  pickDropRequest: { REQUEST: "신청", NOT_REQUEST: "미신청" },
+  pickDropType: { ONE_WAY: "편도", ROUND: "왕복" },
+  pickDropState: { RUNNING: "운영", NOT_RUNNING: "미운영" },
+  ticketType: { ROUND: "회차권", MONTHLY: "정기권" }
+} as const;
+
+export type FieldMappingType = typeof FIELD_MAPPING;
+export type FieldKey = keyof FieldMappingType;
+export type BeFieldType<K extends FieldKey> = keyof FieldMappingType[K];
+export type FeFieldType<K extends FieldKey> = FieldMappingType[K][BeFieldType<K>];

--- a/src/libs/adapters/index.ts
+++ b/src/libs/adapters/index.ts
@@ -1,3 +1,4 @@
 export * from "./Adapter";
 export * from "./FormToServerAdapter";
 export * from "./ServerToFormAdapter";
+export * from "./adaptor";

--- a/src/types/admin/attendance.type.ts
+++ b/src/types/admin/attendance.type.ts
@@ -1,8 +1,12 @@
-import { AttendanceStatus } from "types/common/status.types";
-
-import type { MemberDtoType } from "./enrollment.types";
-import type { Nullable } from "../helper.types";
+import type { Nullable, LocalDateTime, LocalDate } from "../helper.types";
+import type { PoopStatus, AgendaStatus } from "types/member/dogs";
 import type { TicketType } from "types/member/enrollment.types";
+
+export const ATTENDANCE_STATUS = {
+  ATTENDED: "ATTENDED",
+  NOT_ATTENDED: "NOT_ATTENDED"
+} as const;
+export type AttendanceStatus = (typeof ATTENDANCE_STATUS)[keyof typeof ATTENDANCE_STATUS];
 
 /**
  *  @description 출석부 - 출석모드 Dto
@@ -54,23 +58,45 @@ export interface DogInfoDetailData {
   breedId: number;
   breedName: string;
   birthDate: number[];
-  neutralization: string;
-  allergyDisease: string;
-  vaccination: string;
-  fileUrl: string[];
-  pickDropRequest: string;
-  pickDropType: string;
-  pickDropMemo: string;
-  dogMemo: string;
-  member: MemberDtoType;
+  neutralization: "NEUTERED" | "NOT_NEUTERED";
+  allergyDisease: Nullable<string>;
+  vaccination: "VACCINATED" | "NOT_VACCINATED";
+  profileUri: Nullable<string>;
+  vaccinationUri: Nullable<Vaccination[]>;
+  pickDropRequest: "REQUEST" | "NOT_REQUEST";
+  pickDropType: Nullable<"ROUND" | "ONE_WAY">;
+  pickDropMemo: Nullable<string>;
+  dogMemo: Nullable<string>;
+  member: Member;
+}
+
+interface Vaccination {
+  imageId: number;
+  imageUri: string;
+  imageType: "VACCINATION";
+  comment: null;
+  createdTime: number[];
+}
+
+interface Member {
+  memberId: null;
+  memberProfileUri: null;
+  memberName: string;
+  memberGender: null;
+  nickName: null;
+  address: string;
+  addressDetail: Nullable<string>;
+  phoneNumber: string;
+  emergencyNumber: Nullable<string>;
+  relation: null;
 }
 
 /**
  * @description 출석부 강아지 상세 - 강아지 등원기록 Dto
  */
 export interface DogInfoRecordData {
-  date: number[];
-  status: AttendanceStatus;
+  date: LocalDate;
+  status: AgendaStatus;
 }
 
 /**
@@ -80,12 +106,12 @@ export interface DogInfoAgendaData {
   agendaId: number;
   agendaNote: string;
   snack: string;
-  poop: Poop;
+  poop: PoopStatus;
   poopMemo: string;
   dogId: number;
   dogProfileUri: string;
-  status: "NOT_YET" | "COMPLETE" | "WRITING";
-  dateTime: string;
+  status: AgendaStatus;
+  dateTime: LocalDateTime;
 }
 
 export enum Poop {
@@ -104,7 +130,7 @@ export interface TicketDetailData {
   allRoundTicket: number;
   currentRoundTicket: number;
   monthlyTicketNumber: number;
-  ticketStartDate: number[];
+  ticketStartDate: LocalDate;
   ticketExpirationDate: Nullable<number[]>;
   attendanceDays: Nullable<string[]>;
   ticketHistory: Nullable<TicketDetailData[]>;

--- a/src/types/helper.types.ts
+++ b/src/types/helper.types.ts
@@ -3,3 +3,9 @@ export type Nullable<T> = T | null;
 export type PropertyValues<T> = T[keyof T];
 
 export type NonEmptyArray<T> = readonly [T, ...T[]];
+
+/** 날짜만을 표현합니다 (년, 월, 일) */
+export type LocalDate = number[];
+
+/** 날짜와 시간을 모두 표현합니다 (년, 월, 일, 시, 분, 초, 나노초) */
+export type LocalDateTime = number[];

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -30,16 +30,25 @@ export const getCurrentDateString = (): string => {
 };
 
 /**
- * 숫자 또는 숫자 배열의 각 요소를 2자리 문자열로 변환합니다.
- * @param {number | number[]} input - 변환할 숫자 또는 숫자 배열
- * @returns {string | string[]} 변환된 문자열 또는 문자열 배열
+ * 숫자를 2자리 문자열로 변환합니다.
+ * @param {number} input - 변환할 숫자
+ * @returns {string} 변환된 문자열
  */
-export const padToTwoDigits = (input: number | number[]): string | string[] => {
+export function padToTwoDigits(input: number): string;
+
+/**
+ * 숫자 배열의 각 요소를 2자리 문자열로 변환합니다.
+ * @param {number[]} input - 변환할 숫자 배열
+ * @returns {string[]} 변환된 문자열 배열
+ */
+export function padToTwoDigits(input: number[]): string[];
+
+export function padToTwoDigits(input: number | number[]): string | string[] {
   if (Array.isArray(input)) {
     return input.map((n) => n.toString().padStart(2, "0"));
   }
   return input.toString().padStart(2, "0");
-};
+}
 
 /**
  * 숫자 배열을 ISO 8601 문자열로 변환합니다.


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->
- FE - BE 간의 데이터 매핑을 위한 어댑터 패턴 구현
- 이용권 갱신 로직 수정
- 날짜 관련 타입 및 로직 개선

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
#### 1.어댑터 패턴 구현
- `DataFormatAdapter` 클래스 추가: FE-BE 간의 데이터 변환 역할
- `FIELD_MAPPING` 상수 객체 추가: 필드 매핑을 위한 키-값 쌍 정의
#### 2. 이용권 갱신 어댑터 수정
- year, month, day를 `localDate` 타입 형식과 맞게 변환되도록 수정
#### 3. `LocalDate`, `LocalDateTime` 헬퍼 타입 추가
- LocalDate와 LocalDateTime 타입 정의: 백엔드에서 받은 날짜/시간 데이터를 명확하게 구분
#### 4. API 인터페이스 수정
- 백엔드 API 스펙 변경에 따른 인터페이스 업데이트

### DateFormatAdapter Usage

```ts
// 백엔드에서 받은 데이터
const backendData = {
  memberGender: "MALE",
  dogSize: "MEDIUM",
  ticketType: "ROUND"
};

// 어댑터 생성 및 프론트엔드 형식으로 변환
const adapter = new DataFormatAdapter(backendData);
const frontendData = adapter.toFrontend();

console.log(frontendData);
// 출력: { memberGender: "남", dogSize: "중형견", ticketType: "회차권" }

// 프론트엔드 데이터를 백엔드 형식으로 변환
const backendFormattedData = adapter.toBackend();

console.log(backendFormattedData);
// 출력: { memberGender: "MALE", dogSize: "MEDIUM", ticketType: "ROUND" }
```
