### PR TITLE
Fix: Calendar.css 가져오기 제거 및 캘린더 UI 수정

### DIFF
--- a/src/components/Admin/DogDetailInfo/AttendanceRecord/Calendar/Calendar.tsx
+++ b/src/components/Admin/DogDetailInfo/AttendanceRecord/Calendar/Calendar.tsx
@@ -1,0 +1,102 @@
+import { MonthPicker } from "components/Agenda/Calendar/MonthPicker";
+import { CalendarSection } from "components/Agenda/Calendar/styles";
+import { Box } from "components/common";
+import { format, parse, parseISO } from "date-fns";
+import { useGetDogInfoRecord } from "hooks/api/admin/dogs";
+import { useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { getClosestValidDate } from "utils/date";
+
+import { MonthlyCalendar } from "./MonthlyCalendar";
+
+import type { Value } from "react-calendar/dist/cjs/shared/types";
+import type { OnArgs } from "react-calendar/dist/esm";
+
+export function Calendar({ dogId }: { dogId: number }) {
+  const today = new Date();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const currentDateParam = searchParams.get("date");
+  const currentDate = currentDateParam ? parse(currentDateParam, "yyyy-MM-dd", new Date()) : today;
+  const [date, setDate] = useState<Date | null>(currentDate);
+  const [activeStartDate, setActiveStartDate] = useState<Date | null>(currentDate);
+
+  const { data: attendData } = useGetDogInfoRecord(dogId);
+
+  const [showMonthPicker, setShowMonthPicker] = useState(false);
+  const calendarHeaderRef = useRef<HTMLDivElement>(null);
+
+  const handleDateChange = (date: Value) => {
+    if (date instanceof Date) {
+      setDate(date);
+      setActiveStartDate(date);
+      const formattedDate = format(date, "yyyy-MM-dd");
+      searchParams.set("date", formattedDate);
+      setSearchParams(searchParams);
+    }
+  };
+
+  // month가 변경될 때 activeStartDate를 변경해 표시범위를 조정합니다
+  const handleActiveStartDateChange = ({ activeStartDate, view }: OnArgs) => {
+    if (activeStartDate) {
+      setActiveStartDate(activeStartDate);
+      // 'month' 뷰에서만 date 업데이트
+      if (view === "month") {
+        // 가입일 이후, 오늘 이전의 가장 가까운 날짜로 date 변경
+        const selectableDate = getClosestValidDate({
+          date: activeStartDate,
+          maxDate: today,
+          minDate: parseISO("2024-06-28") // FIXME: API 수정 후 지워주세요~~
+        });
+        setDate(selectableDate);
+        const formattedDate = format(selectableDate, "yyyy-MM-dd");
+        searchParams.set("date", formattedDate);
+        setSearchParams(searchParams);
+      }
+    }
+  };
+
+  const handleTodayClick = () => {
+    const today = new Date();
+    handleDateChange(today);
+  };
+
+  const handleMonthClick = (date: Value) => {
+    handleDateChange(date);
+    setShowMonthPicker(false);
+  };
+
+  const handleOpenMonthPicker = () => {
+    setShowMonthPicker(true);
+  };
+
+  const handleCloseMonthPicker = () => {
+    setShowMonthPicker(false);
+  };
+
+  const calendarProps = {
+    today,
+    onDateChange: handleDateChange,
+    onActiveStartDateChange: handleActiveStartDateChange,
+    onTodayClick: handleTodayClick,
+    date,
+    activeStartDate,
+    onOpenMonthPicker: handleOpenMonthPicker,
+    headerRef: calendarHeaderRef
+  };
+
+  return (
+    <CalendarSection>
+      <Box bgColor="white" pt={28} overflow="hidden">
+        <MonthlyCalendar attendData={attendData} {...calendarProps} />
+        <MonthPicker
+          isOpen={showMonthPicker}
+          onClose={handleCloseMonthPicker}
+          onMonthClick={handleMonthClick}
+          date={date}
+          anchorRef={calendarHeaderRef}
+        />
+      </Box>
+    </CalendarSection>
+  );
+}

--- a/src/components/Admin/DogDetailInfo/AttendanceRecord/Calendar/MonthlyCalendar.tsx
+++ b/src/components/Admin/DogDetailInfo/AttendanceRecord/Calendar/MonthlyCalendar.tsx
@@ -1,0 +1,122 @@
+import ArrowLeftIcon from "assets/svg/arrow-left-icon";
+import ArrowRightIcon from "assets/svg/arrow-right-icon";
+import { GoToTodayButton } from "components/Agenda/Calendar/styles";
+import { format, isSameDay, parseISO } from "date-fns";
+import { useCallback, useEffect, useRef } from "react";
+import Calendar from "react-calendar";
+import { OnArgs } from "react-calendar/dist/esm";
+
+import { Dot, StyledMonthlyCalendar, TileText } from "./styles";
+
+import type { DogInfoRecordType } from "hooks/api/admin/dogs";
+import type { Value } from "react-calendar/dist/cjs/shared/types";
+
+interface MonthlyCalendarProps {
+  attendData: DogInfoRecordType[];
+  today: Date;
+  onDateChange: (newDate: Value) => void;
+  onTodayClick: () => void;
+  date: Date | null;
+  activeStartDate: Date | null;
+  onActiveStartDateChange: (arg: OnArgs) => void;
+  onOpenMonthPicker: () => void;
+  headerRef: React.RefObject<HTMLDivElement>;
+}
+
+// FIXME: api 수정이 안돼서 하드코딩함 지워주세요~
+const USER_REGISTRATION_DATE = parseISO("2024-06-28");
+
+export function MonthlyCalendar(props: MonthlyCalendarProps) {
+  const {
+    attendData,
+    today,
+    date,
+    onDateChange,
+    activeStartDate,
+    onActiveStartDateChange,
+    onTodayClick,
+    onOpenMonthPicker,
+    headerRef: calendarRef
+  } = props;
+
+  const todayButtonRef = useRef<HTMLButtonElement>(null);
+
+  const adjustTodayButtonPosition = useCallback(() => {
+    // "오늘" 버튼을 캘린더 타이틀 위치에 정확히 위치하도록 설정
+    if (calendarRef.current && todayButtonRef.current) {
+      const calendarNavigation = calendarRef.current.querySelector(".react-calendar__navigation");
+      const todayButton = todayButtonRef.current;
+
+      if (calendarNavigation) {
+        const navRect = calendarNavigation.getBoundingClientRect();
+        const calendarRect = calendarRef.current.getBoundingClientRect();
+
+        const topOffset =
+          navRect.top - calendarRect.top + (navRect.height - todayButton.offsetHeight) / 2;
+        todayButton.style.top = `${topOffset}px`;
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    adjustTodayButtonPosition();
+    window.addEventListener("resize", adjustTodayButtonPosition);
+
+    return () => {
+      window.removeEventListener("resize", adjustTodayButtonPosition);
+    };
+  }, [adjustTodayButtonPosition]);
+
+  return (
+    <StyledMonthlyCalendar ref={calendarRef}>
+      <Calendar
+        value={date}
+        onChange={onDateChange}
+        activeStartDate={activeStartDate || undefined}
+        onActiveStartDateChange={(args: OnArgs) => onActiveStartDateChange(args)}
+        formatDay={(locale, date: Date) => format(date, "d")}
+        formatWeekday={(locale, date) => format(date, "E")}
+        formatYear={(locale, date: Date) => format(date, "yyyy")}
+        formatMonthYear={(locale, date: Date) => format(date, "yyyy. MM")}
+        minDate={USER_REGISTRATION_DATE}
+        maxDate={new Date()}
+        calendarType="gregory"
+        showNeighboringMonth={false}
+        prevLabel={<ArrowLeftIcon w={24} />}
+        nextLabel={<ArrowRightIcon w={24} />}
+        next2Label={null}
+        prev2Label={null}
+        minDetail="year"
+        view="month"
+        onDrillUp={onOpenMonthPicker}
+        tileContent={({ date, view }) => (
+          <TileContent attendData={attendData} date={date} view={view} today={today} />
+        )}
+      />
+      <GoToTodayButton type="button" ref={todayButtonRef} onClick={onTodayClick}>
+        오늘
+      </GoToTodayButton>
+    </StyledMonthlyCalendar>
+  );
+}
+
+const TileContent = ({
+  attendData,
+  date,
+  view,
+  today
+}: {
+  attendData: DogInfoRecordType[];
+  date: Date;
+  view: string;
+  today: Date;
+}) => {
+  if (view !== "month") return null;
+
+  return (
+    <>
+      {isSameDay(date, today) && <TileText>오늘</TileText>}
+      {attendData.some((data) => isSameDay(parseISO(data.date), date)) && <Dot />}
+    </>
+  );
+};

--- a/src/components/Admin/DogDetailInfo/AttendanceRecord/Calendar/styles.ts
+++ b/src/components/Admin/DogDetailInfo/AttendanceRecord/Calendar/styles.ts
@@ -1,0 +1,154 @@
+import styled from "styled-components";
+import { remCalc } from "utils/calculator";
+
+export const StyledMonthlyCalendar = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: center;
+  width: 100%;
+
+  padding-inline: 16px;
+
+  .react-calendar {
+    width: 100%;
+    border: none;
+  }
+
+  /* 네비 영역 */
+  .react-calendar__navigation {
+    display: flex;
+    justify-content: center;
+    margin-bottom: ${remCalc(24)};
+
+    button {
+      display: flex;
+      justify-content: center;
+      align-content: center;
+    }
+
+    button:enabled:hover,
+    button:enabled:focus {
+      background-color: ${({ theme }) => theme.colors.white};
+    }
+
+    button:disabled {
+      background-color: ${({ theme }) => theme.colors.white};
+      color: ${({ theme }) => theme.colors.gray_4};
+    }
+
+    .react-calendar__navigation__label {
+      flex-grow: 0.1 !important;
+      font-family: "Pretendard Variable";
+      ${({ theme }) => theme.typo.label1_16_B};
+      color: ${({ theme }) => theme.colors.darkBlack};
+    }
+  }
+
+  /* 날짜 영역 컨테이너 */
+  .react-calendar__viewContainer {
+    padding-inline: 8px;
+  }
+
+  /* WeekDays 영역 */
+  .react-calendar__month-view__weekdays {
+    margin-bottom: ${remCalc(24)};
+    text-transform: uppercase;
+    text-align: center;
+
+    .react-calendar__month-view__weekdays__weekday {
+      flex: 1 !important;
+    }
+
+    .react-calendar__month-view__weekdays__weekday abbr {
+      color: ${({ theme }) => theme.colors.gray_1};
+      ${({ theme }) => theme.typo.label2_14_B};
+    }
+
+    .react-calendar__month-view__weekdays__weekday--weekend abbr[title="Sun"] {
+      color: ${({ theme }) => theme.colors.red_1};
+    }
+  }
+
+  /* days 영역 */
+  .react-calendar__month-view__days {
+    .react-calendar__tile {
+      position: relative;
+      display: grid;
+      grid-template-rows: 0.7fr auto 1.3fr;
+      align-items: center;
+      justify-items: center;
+      flex-basis: calc(100% / 7) !important;
+      max-width: calc(100% / 7);
+      aspect-ratio: 1 / 1;
+
+      /* 날짜 텍스트를 위한 스타일 */
+      abbr {
+        margin-top: -0.2em;
+        grid-row: 2;
+        ${({ theme }) => theme.typo.label2_14_M};
+        font-family: "Pretendard Variable";
+        font-size: small;
+        line-height: 1;
+        color: ${({ theme }) => theme.colors.gray_1};
+        z-index: 1;
+      }
+
+      /* 추가 콘텐츠를 위한 스타일 */
+      > *:not(abbr) {
+        grid-row: 3;
+        margin-top: -0.7em;
+        z-index: 1;
+      }
+
+      /* 배경색과 간격을 위한 가상 요소 */
+      &::after {
+        content: "";
+        position: absolute;
+        width: 65%;
+        height: 65%;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        border-radius: 4px;
+        aspect-ratio: 1 / 1;
+      }
+
+      /* 오늘 날짜 스타일 */
+      &--now::after {
+        background-color: transparent;
+      }
+
+      /* 선택된 날짜 스타일 */
+      &--active::after,
+      &--hasActive::after {
+        background-color: ${({ theme }) => theme.colors.yellow_2};
+      }
+
+      &:disabled {
+        background-color: ${({ theme }) => theme.colors.white};
+        abbr {
+          color: ${({ theme }) => theme.colors.gray_3};
+        }
+      }
+    }
+  }
+`;
+
+export const TileText = styled.p`
+  ${({ theme }) => theme.typo.caption1_10_R};
+  line-height: 1.2;
+  color: ${({ theme }) => theme.colors.br_2};
+`;
+
+export const GoToTodayButton = styled.button``;
+
+export const Dot = styled.div`
+  background-color: ${(props) => props.theme.colors.br_2};
+  border-radius: 50%;
+  width: 0.3rem;
+  height: 0.3rem;
+  position: absolute;
+  top: 60%;
+  left: 50%;
+  transform: translateX(-50%);
+`;

--- a/src/components/Agenda/Calendar/MonthPicker.tsx
+++ b/src/components/Agenda/Calendar/MonthPicker.tsx
@@ -15,14 +15,14 @@ import {
   MonthPickerCalendar
 } from "./styles";
 
+import type { DogInfoRecordType } from "hooks/api/member/dogs";
 import type { Value } from "react-calendar/dist/cjs/shared/types";
-import type { DogInfoRecord } from "types/member/dogs";
 
 interface MonthPickerProps {
-  data: DogInfoRecord[];
+  data?: DogInfoRecordType[];
   isOpen: boolean;
   onClose: () => void;
-  activeDate: Date | null;
+  date: Date | null;
   onMonthClick: (value: Value) => void;
   anchorRef: React.RefObject<HTMLDivElement>;
 }
@@ -34,7 +34,7 @@ export const MonthPicker = ({
   data,
   isOpen,
   onClose,
-  activeDate,
+  date,
   onMonthClick,
   anchorRef
 }: MonthPickerProps) => {
@@ -51,6 +51,8 @@ export const MonthPicker = ({
     if (isOpen && popupRef.current && anchorRef.current) {
       const calendarNavigation = anchorRef.current;
       const popupNavigation = popupRef.current.querySelector(".react-calendar__navigation");
+      console.log(popupNavigation);
+      console.log(calendarNavigation);
 
       if (calendarNavigation && popupNavigation) {
         const calendarRect = calendarNavigation.getBoundingClientRect();
@@ -75,7 +77,7 @@ export const MonthPicker = ({
         <MonthPickerWrapper ref={popupRef}>
           <MonthPickerCalendar>
             <Calendar
-              value={activeDate}
+              value={date}
               onChange={onMonthClick}
               view="year"
               maxDetail="year"

--- a/src/components/Agenda/Calendar/MonthlyCalendar.tsx
+++ b/src/components/Agenda/Calendar/MonthlyCalendar.tsx
@@ -5,21 +5,22 @@ import { Box, Text } from "components/common";
 import { format, isSameDay, parseISO } from "date-fns";
 import React, { useCallback, useEffect, useRef } from "react";
 import Calendar, { type OnArgs } from "react-calendar";
-import { getClosestValidDate } from "utils/date";
 
 import { StyledMonthlyCalendar, GoToTodayButton } from "./styles";
 
+import type { DogInfoRecordType } from "hooks/api/admin/dogs";
 import type { Value } from "react-calendar/dist/cjs/shared/types";
-import type { DogInfoRecord } from "types/member/dogs";
 
 const ATTEND_DAYS = ["2024-07-17", "2024-07-17", "2024-07-21", "2024-07-23"];
 
 interface MonthlyCalendarProps {
-  data: DogInfoRecord[];
+  attendData?: DogInfoRecordType[];
   today: Date;
   onDateChange: (newDate: Value) => void;
   onTodayClick: () => void;
-  activeDate: Date | null;
+  date: Date | null;
+  activeStartDate: Date | null;
+  onActiveStartDateChange: (arg: OnArgs) => void;
   onOpenMonthPicker: () => void;
   headerRef: React.RefObject<HTMLDivElement>;
 }
@@ -51,33 +52,23 @@ const TileContent = ({ date, view, today }: { date: Date; view: string; today: D
  * Monthly Calendar
  * -----------------------------------------------------------------------------------------------*/
 
+// FIXME: api 수정이 안돼서 하드코딩함 지워주세요~
 const USER_REGISTRATION_DATE = parseISO("2024-06-28");
 
 export const MonthlyCalendar = (props: MonthlyCalendarProps) => {
   const {
-    data,
+    attendData,
     today,
-    activeDate,
+    date,
     onDateChange,
+    activeStartDate,
+    onActiveStartDateChange,
     onTodayClick,
     onOpenMonthPicker,
     headerRef: calendarRef
   } = props;
 
   const todayButtonRef = useRef<HTMLButtonElement>(null);
-
-  const handleActiveDateChange = ({ view, activeStartDate }: OnArgs) => {
-    // month가 변경될 때 activeDate를 변경해 표시범위를 조정
-    if (view === "month" && activeStartDate) {
-      // 가입일 이후, 오늘 이전의 가장 가까운 날짜로 activeDate를 변경
-      const selectableDate = getClosestValidDate({
-        date: activeStartDate,
-        maxDate: today,
-        minDate: USER_REGISTRATION_DATE
-      });
-      onDateChange(selectableDate);
-    }
-  };
 
   const adjustTodayButtonPosition = useCallback(() => {
     // "오늘" 버튼을 캘린더 타이틀 위치에 정확히 위치하도록 설정
@@ -108,10 +99,10 @@ export const MonthlyCalendar = (props: MonthlyCalendarProps) => {
   return (
     <StyledMonthlyCalendar ref={calendarRef}>
       <Calendar
-        value={activeDate}
+        value={date}
         onChange={onDateChange}
-        activeStartDate={activeDate || undefined}
-        onActiveStartDateChange={handleActiveDateChange}
+        activeStartDate={activeStartDate || undefined}
+        onActiveStartDateChange={(args: OnArgs) => onActiveStartDateChange(args)}
         formatDay={(locale, date) => format(date, "d")}
         formatWeekday={(locale, date) => format(date, "E")}
         formatMonthYear={(locale, date) => format(date, "yyyy. MM")}

--- a/src/components/Agenda/Calendar/styles.ts
+++ b/src/components/Agenda/Calendar/styles.ts
@@ -9,12 +9,12 @@ export const CalendarSection = styled.section`
   margin-bottom: 40px;
 `;
 
-// Styled Monthly Calendar Container
+// MonthlyCalendar Style
 export const StyledMonthlyCalendar = styled.div`
-  width: 100%;
   display: flex;
-  justify-content: center;
   position: relative;
+  justify-content: center;
+  width: 100%;
 
   /* React Calendar Custom Styling */
   .react-calendar {
@@ -161,21 +161,20 @@ export const MonthPickerCalendar = styled.div`
 
   /* Navigation Styling */
   .react-calendar__navigation {
+    display: flex;
     justify-content: center;
-    gap: 10px;
-    margin: 0;
 
-    button:enabled:hover,
-    button:enabled:focus,
-    button:disabled {
-      background-color: ${({ theme }) => theme.colors.white};
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
-    .react-calendar__navigation__label {
+    button.react-calendar__navigation__label {
       ${({ theme }) => theme.typo.label1_16_B};
       color: ${({ theme }) => theme.colors.primaryColor};
       font-family: "Pretendard Variable";
-      flex-grow: 0 !important;
+      flex-grow: 0.3 !important;
     }
   }
 
@@ -217,7 +216,7 @@ export const MonthPickerCalendar = styled.div`
       }
     }
 
-    &.react-calendar__tile: disabled {
+    &.react-calendar__tile:disabled {
       abbr {
         color: ${({ theme }) => theme.colors.gray_4};
       }

--- a/src/components/common/Calendar/AllCalendar.tsx
+++ b/src/components/common/Calendar/AllCalendar.tsx
@@ -10,6 +10,7 @@ import * as S from "./styles";
 type ValuePiece = Date | null;
 type Value = ValuePiece | [ValuePiece, ValuePiece];
 
+// FIXME: API 수정 후 타입에러 해결나는거 해결하고 반영하겠습니다.
 const Calendar = () => {
   const today = new Date();
   const [date, setDate] = useState<Value>(today);
@@ -33,36 +34,36 @@ const Calendar = () => {
 
   return (
     <S.CalendarWrapper>
-      <S.StyledCalendar
-        value={date}
-        onChange={handleDateChange}
-        activeStartDate={activeStartDate === null ? undefined : activeStartDate}
-        onActiveStartDateChange={({ activeStartDate }: { activeStartDate: Date | null }) =>
-          setActiveStartDate(activeStartDate)
-        }
-        formatDay={(locale: any, date: moment.MomentInput) => moment(date).format("D")}
-        formatYear={(locale: any, date: moment.MomentInput) => moment(date).format("YYYY")}
-        formatMonthYear={(locale: any, date: moment.MomentInput) => moment(date).format("YYYY. MM")}
-        calendarType="gregory"
-        showNeighboringMonth={false}
-        next2Label={null}
-        prev2Label={null}
-        minDetail="year"
-        tileContent={({ date, view }: { date: Date; view: string }) => {
-          const html = [];
-          if (
-            view === "month" &&
-            date.getMonth() === today.getMonth() &&
-            date.getDate() === today.getDate()
-          ) {
-            html.push(<S.Today key={"today"}>오늘</S.Today>);
-          }
-          if (attendDay.find((x) => x === moment(date).format("YYYY-MM-DD"))) {
-            html.push(<FootIcon className="footIcon" key={moment(date).format("YYYY-MM-DD")} />);
-          }
-          return <>{html}</>;
-        }}
-      />
+      {/*<S.StyledCalendar*/}
+      {/*  value={date}*/}
+      {/*  onChange={handleDateChange}*/}
+      {/*  activeStartDate={activeStartDate === null ? undefined : activeStartDate}*/}
+      {/*  onActiveStartDateChange={({ activeStartDate }: { activeStartDate: Date | null }) =>*/}
+      {/*    setActiveStartDate(activeStartDate)*/}
+      {/*  }*/}
+      {/*  formatDay={(locale: any, date: moment.MomentInput) => moment(date).format("D")}*/}
+      {/*  formatYear={(locale: any, date: moment.MomentInput) => moment(date).format("YYYY")}*/}
+      {/*  formatMonthYear={(locale: any, date: moment.MomentInput) => moment(date).format("YYYY. MM")}*/}
+      {/*  calendarType="gregory"*/}
+      {/*  showNeighboringMonth={false}*/}
+      {/*  next2Label={null}*/}
+      {/*  prev2Label={null}*/}
+      {/*  minDetail="year"*/}
+      {/*  tileContent={({ date, view }: { date: Date; view: string }) => {*/}
+      {/*    const html = [];*/}
+      {/*    if (*/}
+      {/*      view === "month" &&*/}
+      {/*      date.getMonth() === today.getMonth() &&*/}
+      {/*      date.getDate() === today.getDate()*/}
+      {/*    ) {*/}
+      {/*      html.push(<S.Today key={"today"}>오늘</S.Today>);*/}
+      {/*    }*/}
+      {/*    if (attendDay.find((x) => x === moment(date).format("YYYY-MM-DD"))) {*/}
+      {/*      html.push(<FootIcon className="footIcon" key={moment(date).format("YYYY-MM-DD")} />);*/}
+      {/*    }*/}
+      {/*    return <>{html}</>;*/}
+      {/*  }}*/}
+      {/*/>*/}
       <S.Date onClick={handleTodayClick}>오늘</S.Date>
     </S.CalendarWrapper>
   );

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -1,6 +1,6 @@
 import { createGlobalStyle } from "styled-components";
 import reset from "styled-reset";
-import "./CalendarStyle";
+// import "./CalendarStyle";
 
 export const GlobalStyle = createGlobalStyle`
 ${reset}
@@ -58,6 +58,10 @@ select {
 
 textarea:focus, input:focus{
     outline: none;
+}
+
+abbr {
+  text-decoration: none;
 }
 
 // Input type number 일때 input 오른쪽 화살표 없애기


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->
React Calendar에서 제공하는 css를 가져오는 구문을 제거했습니다. (전역 스코프 오염 이유 때문에)
이에 맞춰 캘린더 UI를 다시 수정했습니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

- 출석부 > 강아지 상세 등원기록 Calendar 추가
- [Calendar activeStartDate / date 분리](https://github.com/PetCampus-Inc/daeng_v1_front/pull/216/commits/5dfb69a5ce917527a7eaa5ff13329f1423eacff2)

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

현재 여러 페이지에서 React-Calendar 라이브러리를 기반으로 각각 캘린더를 구현하여 사용 중입니다. admin/member 페이지와 주간/월간 뷰에 따라 UI가 달라지지만, 대부분의 로직이 중복되고 있습니다. 공통 컴포넌트로 개발해봐도 좋을 것 같아욤..!

