### PR TITLE
Fix: 가입신청서 생성 시 pickDropInfo requireItemList에서 제외

### DIFF
--- a/src/components/Admin/EnrollmentForm/CreateForm/PickDropInfo.tsx
+++ b/src/components/Admin/EnrollmentForm/CreateForm/PickDropInfo.tsx
@@ -29,6 +29,7 @@ const PickDropInfo = () => {
             <AdminTitle
               name={`${FIELD.REQUEST_ITEMS}.${FIELD_KEYS.PICKDROP_NOTICE}`}
               control={control}
+              noToggle
               hasBadge
             >
               픽드랍 안내

--- a/src/components/Admin/EnrollmentForm/EditForm/PickDropInfo.tsx
+++ b/src/components/Admin/EnrollmentForm/EditForm/PickDropInfo.tsx
@@ -29,6 +29,7 @@ const PickDropInfo = () => {
             <AdminTitle
               name={`${FIELD.REQUEST_ITEMS}.${FIELD_KEYS.PICKDROP_NOTICE}`}
               control={control}
+              noToggle
               hasBadge
             >
               픽드랍 안내

--- a/src/components/Admin/EnrollmentForm/Stepper/Navigation.tsx
+++ b/src/components/Admin/EnrollmentForm/Stepper/Navigation.tsx
@@ -1,3 +1,6 @@
+import AlertBottomSheet from "components/common/BottomSheet/AlertBottomSheet";
+import { useOverlay } from "hooks/common/useOverlay/useOverlay";
+import { useFormContext } from "react-hook-form";
 import { FormButton, FormButtonWrapper, FormPrevButton } from "styles/StyleModule";
 
 import SubmitButton from "./SubmitButton";
@@ -19,14 +22,35 @@ const Navigation = ({
   prevStep,
   onNextStep
 }: NavigationProps) => {
+  const { setFocus } = useFormContext();
+  const overlay = useOverlay();
+
   const isFirstStep = currentStep === 0;
   const isLastStep = currentStep === stepsLength - 1;
+
+  const openAlertPopup = (field: string) =>
+    overlay.open(({ isOpen, close }) => (
+      <AlertBottomSheet
+        isOpen={isOpen}
+        close={() => {
+          close();
+          setFocus(field);
+        }}
+        title="입력을 하지 않은 필수 항목이 있어요"
+        subtitle="유의사항에 동의하지 않으면 가입이 어려워요"
+        actionText="확인"
+        actionFn={() => {
+          close();
+          setFocus(field);
+        }}
+      />
+    ));
 
   return (
     <FormButtonWrapper>
       {!isFirstStep && !isLastStep && <FormPrevButton onClick={prevStep}>이전</FormPrevButton>}
       {!isLastStep && <FormButton onClick={nextStep}>다음</FormButton>}
-      {isLastStep && <SubmitButton onNextStep={onNextStep} />}
+      {isLastStep && <SubmitButton onNextStep={onNextStep} onOpenPopup={openAlertPopup} />}
     </FormButtonWrapper>
   );
 };

--- a/src/components/Admin/EnrollmentForm/Stepper/NavigationButton.tsx
+++ b/src/components/Admin/EnrollmentForm/Stepper/NavigationButton.tsx
@@ -1,0 +1,36 @@
+import AlertBottomSheet from "components/common/BottomSheet/AlertBottomSheet";
+import { useOverlay } from "hooks/common/useOverlay";
+import { useFormContext } from "react-hook-form";
+
+import SubmitButton from "./SubmitButton";
+
+import type { AdminEnrollmentInfoType } from "types/admin/enrollment.types";
+
+export const NavigationButton = ({
+  onNextStep
+}: {
+  onNextStep?: (formInfo: AdminEnrollmentInfoType) => void;
+}) => {
+  const { setFocus } = useFormContext();
+
+  const overlay = useOverlay();
+  const openAlertPopup = (field: string) =>
+    overlay.open(({ isOpen, close }) => (
+      <AlertBottomSheet
+        isOpen={isOpen}
+        close={() => {
+          close();
+          setFocus(field);
+        }}
+        title="입력을 하지 않은 필수 항목이 있어요"
+        subtitle="유의사항에 동의하지 않으면 가입이 어려워요"
+        actionText="확인"
+        actionFn={() => {
+          close();
+          setFocus(field);
+        }}
+      />
+    ));
+
+  return <SubmitButton type="EDIT" onNextStep={onNextStep} onOpenPopup={openAlertPopup} />;
+};

--- a/src/components/Admin/EnrollmentForm/Stepper/SubmitButton.tsx
+++ b/src/components/Admin/EnrollmentForm/Stepper/SubmitButton.tsx
@@ -1,8 +1,6 @@
 import { getFieldStep } from "constants/step";
 
-import AlertBottomSheet from "components/common/BottomSheet/AlertBottomSheet";
 import { useAdminInfo } from "hooks/common/useAdminInfo";
-import { useOverlay } from "hooks/common/useOverlay";
 import { Adapter } from "libs/adapters";
 import { AdminFormToServerAdapter } from "libs/adapters/FormToServerAdapter";
 import { FieldErrors, FieldValues, useFormContext } from "react-hook-form";
@@ -15,34 +13,16 @@ import type { AdminEnrollmentInfoType } from "types/admin/enrollment.types";
 interface SubmitButtonProps {
   type?: "READ" | "CREATE" | "EDIT";
   onNextStep?: (formInfo: AdminEnrollmentInfoType) => void;
+  onOpenPopup: (field: string) => void;
 }
 
-const SubmitButton = ({ type, onNextStep }: SubmitButtonProps) => {
-  const { handleSubmit, setFocus } = useFormContext();
-  const overlay = useOverlay();
+const SubmitButton = ({ type, onNextStep, onOpenPopup }: SubmitButtonProps) => {
+  const { handleSubmit } = useFormContext();
 
   const setStep = useSetRecoilState(currentStepState);
   const { adminId, schoolId } = useAdminInfo();
 
   const text = type === "EDIT" ? "수정 완료" : "가입 신청서 등록";
-
-  const openPopup = (field: string) =>
-    overlay.open(({ isOpen, close }) => (
-      <AlertBottomSheet
-        isOpen={isOpen}
-        close={() => {
-          close();
-          setFocus(field);
-        }}
-        title="입력을 하지 않은 필수 항목이 있어요"
-        subtitle="유의사항에 동의하지 않으면 가입이 어려워요"
-        actionText="확인"
-        actionFn={() => {
-          close();
-          setFocus(field);
-        }}
-      />
-    ));
 
   const onSubmit = (data: FieldValues) => {
     const requestData = { ...data, adminId, schoolId };
@@ -57,7 +37,7 @@ const SubmitButton = ({ type, onNextStep }: SubmitButtonProps) => {
     const step = getFieldStep({ field: firstErrorField, enable: true });
     if (step !== undefined) {
       setStep(step);
-      openPopup(firstErrorField);
+      onOpenPopup(firstErrorField);
     }
   };
 

--- a/src/components/Admin/EnrollmentForm/TicketType/index.tsx
+++ b/src/components/Admin/EnrollmentForm/TicketType/index.tsx
@@ -5,6 +5,7 @@ import { Modal } from "components/common/Modal";
 import EditableRadioGroup from "components/common/Select/EditableRadioGroup";
 import { useOverlay } from "hooks/common/useOverlay";
 import useTicketFieldArray from "hooks/common/useTicketFieldArray";
+import React from "react";
 import { useRecoilCallback } from "recoil";
 import { ticketCounterState } from "store/form";
 
@@ -20,84 +21,90 @@ type TicketTypeProps = {
   defaultValues?: number[];
 };
 
-const TicketType = ({ control, name, ticketType, defaultValues = [] }: TicketTypeProps) => {
-  const FIELD_NAME = name;
-  const MAX_ITEMS = 6;
-  const MIN_ITEMS = 1;
-  const TICKET_TYPE = ticketType === "ROUND" ? "회차권" : "정기권";
-  const TIMES = ticketType === "ROUND" ? "회" : "주";
+const TicketType = React.memo(
+  ({ control, name, ticketType, defaultValues = [] }: TicketTypeProps) => {
+    const FIELD_NAME = name;
+    const MAX_ITEMS = 6;
+    const MIN_ITEMS = 1;
+    const TICKET_TYPE = ticketType === "ROUND" ? "회차권" : "정기권";
+    const TIMES = ticketType === "ROUND" ? "회" : "주";
 
-  const { fields, append, remove } = useTicketFieldArray({
-    control,
-    fieldName: FIELD_NAME,
-    defaultValues
-  });
+    const { fields, append, remove } = useTicketFieldArray({
+      control,
+      fieldName: FIELD_NAME,
+      defaultValues
+    });
 
-  const overlay = useOverlay();
+    const overlay = useOverlay();
 
-  const handleAddRadio = useRecoilCallback(
-    ({ set, snapshot }) =>
-      async () => {
-        const counter = await snapshot.getPromise(ticketCounterState);
+    const handleAddRadio = useRecoilCallback(
+      ({ set, snapshot }) =>
+        async () => {
+          const counter = await snapshot.getPromise(ticketCounterState);
 
-        if (fields.length < MAX_ITEMS) {
-          append({ value: counter });
-          overlay.close();
-          set(ticketCounterState, INIT_COUNTER);
-        } else {
-          alert("더 이상 추가할 수 없습니다.");
-        }
-      },
-    []
-  );
+          if (fields.length < MAX_ITEMS) {
+            append({ value: counter });
+            overlay.close();
+            set(ticketCounterState, INIT_COUNTER);
+          } else {
+            alert("더 이상 추가할 수 없습니다.");
+          }
+        },
+      []
+    );
 
-  const handleRemove = (index: number) => {
-    if (fields.length > MIN_ITEMS) {
-      remove(index);
-    } else {
-      openDeleteModal();
-    }
-  };
+    const handleRemove = (index: number) => {
+      if (fields.length > MIN_ITEMS) {
+        remove(index);
+      } else {
+        openDeleteModal();
+      }
+    };
 
-  const openTicketCounter = () =>
-    overlay.open(({ isOpen, close }) => (
-      <TicketCounterBottomSheet
-        isOpen={isOpen}
-        close={close}
-        ticketType={ticketType}
-        fields={fields}
-        action={handleAddRadio}
-      />
-    ));
+    const openTicketCounter = () =>
+      overlay.open(({ isOpen, close }) => (
+        <TicketCounterBottomSheet
+          isOpen={isOpen}
+          close={close}
+          ticketType={ticketType}
+          fields={fields}
+          action={handleAddRadio}
+        />
+      ));
 
-  const openDeleteModal = () =>
-    overlay.open(({ isOpen, close }) => (
-      <Modal isOpen={isOpen} close={close}>
-        <Modal.Content>
-          <Modal.Title
-            title="모두 삭제할 수 없어요"
-            subtitle={`최소 1개 이상의 ${TICKET_TYPE} 옵션을 추가해 주세요`}
-          />
-          <Modal.Button actionText="닫기" actionFn={close} />
-        </Modal.Content>
-      </Modal>
-    ));
+    const openDeleteModal = () =>
+      overlay.open(({ isOpen, close }) => (
+        <Modal isOpen={isOpen} close={close}>
+          <Modal.Content>
+            <Modal.Title
+              title="모두 삭제할 수 없어요"
+              subtitle={`최소 1개 이상의 ${TICKET_TYPE} 옵션을 추가해 주세요`}
+            />
+            <Modal.Button actionText="닫기" actionFn={close} />
+          </Modal.Content>
+        </Modal>
+      ));
 
-  return (
-    <>
-      <EditableRadioGroup
-        control={control}
-        suffix={TIMES}
-        name={FIELD_NAME}
-        fields={fields}
-        remove={handleRemove}
-      />
-      <S.AddButton type="button" onClick={openTicketCounter} disabled={fields.length >= MAX_ITEMS}>
-        <AddIcon />
-        {TICKET_TYPE} 직접 추가
-      </S.AddButton>
-    </>
-  );
-};
+    return (
+      <>
+        <EditableRadioGroup
+          control={control}
+          suffix={TIMES}
+          name={FIELD_NAME}
+          fields={fields}
+          remove={handleRemove}
+        />
+        <S.AddButton
+          type="button"
+          onClick={openTicketCounter}
+          disabled={fields.length >= MAX_ITEMS}
+        >
+          <AddIcon />
+          {TICKET_TYPE} 직접 추가
+        </S.AddButton>
+      </>
+    );
+  }
+);
 
 export default TicketType;

--- a/src/pages/AdminSchoolMangePage/EnrollmentPage/EnrollmentFormEditPage.tsx
+++ b/src/pages/AdminSchoolMangePage/EnrollmentPage/EnrollmentFormEditPage.tsx
@@ -6,7 +6,7 @@ import PickDropInfo from "components/Admin/EnrollmentForm/EditForm/PickDropInfo"
 import PolicyInfo from "components/Admin/EnrollmentForm/EditForm/PolicyInfo";
 import TicketInfo from "components/Admin/EnrollmentForm/EditForm/TicketInfo";
 import Indicator from "components/Admin/EnrollmentForm/Stepper/Indicator";
-import SubmitButton from "components/Admin/EnrollmentForm/Stepper/SubmitButton";
+import { NavigationButton } from "components/Admin/EnrollmentForm/Stepper/NavigationButton";
 import {
   Container,
   TopWrapper,
@@ -92,8 +92,9 @@ const EnrollmentFormEditPage = ({ onNextStep }: EnrollmentFormEditProps) => {
               </Content>
             </ContentWrapper>
             <ButtonContainer>
+              type="EDIT"
               <HelperText>변경된 내용으로 새로 저장 돼요</HelperText>
-              <SubmitButton type="EDIT" onNextStep={onNextStep} />
+              <NavigationButton onNextStep={onNextStep} />
             </ButtonContainer>
           </FormProvider>
         </Container>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
가입신청서 생성 시 pickDropInfo가 필수항목으로 들어가고 있어서 requireItemList에서 제외했습니다.


<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

- [fix: SubmitButton에서 AlertBottomSheet 분리](https://github.com/PetCampus-Inc/daeng_v1_front/commit/347e82293c9fc6d006459417a5e50386f29f528a)
- [refactor: TicketType 리렌더 방지 memo 추가](https://github.com/PetCampus-Inc/daeng_v1_front/commit/69f198cc4256f41bc35610aa83e6ad7dd4b0fcb4)
- [fix: 픽드랍 안내 필드 토글 제거](https://github.com/PetCampus-Inc/daeng_v1_front/commit/050e8ce3bc77ddcca6e743c42cca772d3f433dac)

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

SubmitButton 라이프사이클 주기에 알럿 팝업이 영향을 받으면 안돼서 SubmitButton에서 알럿 팝업을 분리했습니당.. 급하게 수정한거라 리팩터링 해줘야함

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
