### PR TITLE
Hotfix: 가입신청서 플로우 중 유치원 검색 다음 버튼 클릭 시 팝업 드는 이슈 해결

### DIFF
--- a/src/pages/SignUpPage/SearchSchoolPage.tsx
+++ b/src/pages/SignUpPage/SearchSchoolPage.tsx
@@ -7,6 +7,7 @@ import { StyledButton } from "components/SignIn/styles";
 import SchoolSearchInputBox from "components/SignUp/SearchSchool/SchoolSearchInputBox";
 import { useSetLocalStorage } from "hooks/common/useLocalStorage";
 import { memo, useState } from "react";
+import { useFormState } from "react-hook-form";
 import { useBlocker } from "react-router-dom";
 import { User } from "types/common/role.types";
 
@@ -24,6 +25,7 @@ interface SearchSchoolPageProps {
 const SearchSchoolPage = ({ type, onNextStep, btnText }: SearchSchoolPageProps) => {
   const setLocalStorage = useSetLocalStorage();
   const [selectedSchool, setSelectedSchool] = useState<SelectedSchool | null>(null);
+  const [isNextClicked, setIsNextClicked] = useState(false);
 
   const handleSelect = (id: number, name: string) => setSelectedSchool({ id, name });
   const handleClear = () => setSelectedSchool(null);
@@ -33,7 +35,7 @@ const SearchSchoolPage = ({ type, onNextStep, btnText }: SearchSchoolPageProps) 
     setLocalStorage(SCHOOL_NAME_KEY, selectedSchool.name);
   };
 
-  const blocker = useBlocker(() => !!selectedSchool);
+  const blocker = useBlocker(() => !!selectedSchool && !isNextClicked);
 
   return (
     <>
@@ -59,7 +61,10 @@ const SearchSchoolPage = ({ type, onNextStep, btnText }: SearchSchoolPageProps) 
           <StyledButton
             type="button"
             bg="primaryColor"
-            onClick={handleNextClick}
+            onClick={() => {
+              handleNextClick();
+              setIsNextClicked(true);
+            }}
             disabled={!selectedSchool}
           >
             <Text className={selectedSchool ? "" : "inactive"} typo="label1_16_B" color="white">


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

- [x] 유치원 검색 후 다음 버튼 클릭 시 팝업창 뜨는 이슈를 해결하기 위해 조건문 추가

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

마이페이지에서 강아지 추가, 유치원 재가입 플로우 중 유치원 검색 후 다음 클릭 시 팝업창이 나와 조건문을 추가하게 되었습니다.
회원가입시 작성하는 가입신청서에서도 잘 작동 되는지 확인이 필요할 것 같습니다!

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->


https://github.com/user-attachments/assets/c9944439-0f77-412d-b785-7546ee93d6a6


