### PR TITLE
Fix: [2차 QA] 견주 마이페이지 관련 이슈

### DIFF
--- a/src/apis/member/member.api.ts
+++ b/src/apis/member/member.api.ts
@@ -255,3 +255,10 @@ export const handlePostDogProfile = async (req: DogProfileReq) => {
   });
   return data;
 };
+
+// FIXME 회원 탈퇴 기능 추가 필요
+// 회원 탈퇴
+export const handleDeleteMember = async () => {
+  const url = `member/delete/member`;
+  return await authAxios.post(url);
+};

--- a/src/components/Admin/MyPage/DeleteAccount/index.tsx
+++ b/src/components/Admin/MyPage/DeleteAccount/index.tsx
@@ -1,5 +1,6 @@
 import { routes } from "constants/path";
 
+import ExclamationMarkIcon from "assets/svg/exclamationMark-icon";
 import { Box, Checkbox, Flex, Layout, Text } from "components/common";
 import { BottomButton } from "components/common/Button";
 import Header from "components/common/Header";
@@ -8,6 +9,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Role } from "types/common/role.types";
 
+import * as S from "./styles";
 interface DeleteAccountProps {
   setStep: (step: number) => void;
   role: string;
@@ -60,34 +62,36 @@ const DeleteAccount = ({ setStep, role }: DeleteAccountProps) => {
   };
 
   const renderCheckboxItem = (key: keyof ContentCheck, text: string, marginTop: number) => (
-    <Box
-      width="100%"
-      border={1}
-      borderRadius={8}
-      borderColor={contents[key] ? "transparent" : "gray_4"}
-      backgroundColor={contents[key] ? "br_5" : "transparent"}
-      padding={12}
-      marginTop={marginTop}
-    >
-      <Checkbox
-        onChange={() => checkIndividual(key)}
-        isChecked={contents[key]}
-        variant="default"
-        label={
-          <Text color="gray_1">
-            {text.split(/(<.*?>)/g).map((segment, index) =>
-              /<.*?>/.test(segment) ? (
-                <Text key={index} color="primaryColor">
-                  {segment.replace(/<|>/g, "")}
-                </Text>
-              ) : (
-                segment
-              )
-            )}
-          </Text>
-        }
-      />
-    </Box>
+    <S.CheckboxWrapper>
+      <Box
+        width="100%"
+        border={1}
+        borderRadius={8}
+        borderColor={contents[key] ? "transparent" : "gray_4"}
+        backgroundColor={contents[key] ? "br_5" : "white"}
+        padding={12}
+        marginTop={marginTop}
+      >
+        <Checkbox
+          onChange={() => checkIndividual(key)}
+          isChecked={contents[key]}
+          variant="default"
+          label={
+            <Text color="gray_1">
+              {text.split(/(<.*?>)/g).map((segment, index) =>
+                /<.*?>/.test(segment) ? (
+                  <Text key={index} color="primaryColor">
+                    {segment.replace(/<|>/g, "")}
+                  </Text>
+                ) : (
+                  segment
+                )
+              )}
+            </Text>
+          }
+        />
+      </Box>
+    </S.CheckboxWrapper>
   );
 
   return (
@@ -119,29 +123,35 @@ const DeleteAccount = ({ setStep, role }: DeleteAccountProps) => {
             15
           )}
         {role === Role.ROLE_OWNER && renderCheckboxItem(4, "모든 <개인 정보>가 삭제돼요", 15)}
-        <Box
-          width="100%"
-          border={1}
-          borderRadius={8}
-          borderColor={`${isAllChecked ? "transparent" : "gray_4"}`}
-          backgroundColor={`${isAllChecked ? "br_4" : "transparent"}`}
-          padding={12}
-          marginTop={60}
-        >
-          <Checkbox
-            onChange={checkAll}
-            isChecked={isAllChecked}
-            variant="default"
-            label={
-              <Text color={`${isAllChecked ? "primaryColor" : "gray_1"}`}>
-                위 안내사항에 모두 동의해요
-              </Text>
-            }
-          />
-        </Box>
+        <S.CheckboxWrapper>
+          <Box
+            width="100%"
+            border={1}
+            borderRadius={8}
+            borderColor={`${isAllChecked ? "transparent" : "gray_4"}`}
+            backgroundColor={`${isAllChecked ? "br_4" : "white"}`}
+            padding={12}
+            marginTop={60}
+          >
+            <Checkbox
+              onChange={checkAll}
+              isChecked={isAllChecked}
+              variant="default"
+              label={
+                <Text color={`${isAllChecked ? "primaryColor" : "gray_1"}`}>
+                  위 안내사항에 모두 동의해요
+                </Text>
+              }
+            />
+          </Box>
+        </S.CheckboxWrapper>
+
         <BottomButton onClick={onSubmit} disabled={!isAllChecked}>
           탈퇴하기
         </BottomButton>
+        <S.ExclamationMark>
+          <ExclamationMarkIcon />
+        </S.ExclamationMark>
       </Layout>
     </>
   );

--- a/src/components/Admin/MyPage/DeleteAccount/styles.ts
+++ b/src/components/Admin/MyPage/DeleteAccount/styles.ts
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+export const ExclamationMark = styled.div`
+  position: absolute;
+  right: -2rem;
+  bottom: 5.8125rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 100%;
+  width: 236px;
+  height: 236px;
+  background-color: ${({ theme }) => theme.colors.gray_5};
+  z-index: -1;
+`;
+
+export const CheckboxWrapper = styled.div`
+  & > div > label > span:first-of-type {
+    flex-shrink: 0;
+  }
+`;

--- a/src/components/Member/MyPage/Buttons/RoleEditButton.tsx
+++ b/src/components/Member/MyPage/Buttons/RoleEditButton.tsx
@@ -1,49 +1,40 @@
 import { FIELD } from "constants/field";
 import { RELATION_DATA, RELATION_DATA_ARR } from "constants/relation";
 
+import RoleBottomSheet from "components/Member/Profile/BottomSheet/RoleBottomSheet";
+import { useOverlay } from "hooks/common/useOverlay";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 
 import * as S from "./styles";
 
-interface RoleEditButtonProps {
-  isShowRoles: boolean;
-  handleShowRoles: () => void;
-}
-
-const RoleEditButton = ({ isShowRoles, handleShowRoles }: RoleEditButtonProps) => {
-  const { setValue, getValues } = useFormContext();
-
+const RoleEditButton = () => {
+  const overlay = useOverlay();
+  const { register, getValues } = useFormContext();
   const [currentRelation, setCurrentRelation] = useState<string>(
     RELATION_DATA[getValues(FIELD.RELATION)]
   );
 
-  const notSelectedRelation = RELATION_DATA_ARR.filter((item) => item.relation !== currentRelation);
+  const openRoleSelectPopup = () =>
+    overlay.open(({ isOpen, close }) => (
+      <RoleBottomSheet
+        isOpen={isOpen}
+        close={close}
+        actionFn={handleSelectedRelation}
+        register={register}
+        title="호칭선택"
+      />
+    ));
 
   const handleSelectedRelation = (relation: string) => {
     setCurrentRelation(RELATION_DATA[relation]);
-    setValue(FIELD.RELATION, relation, { shouldDirty: true });
   };
 
   return (
     <>
-      <S.RoleEditButton color="gray_1" bg="white" onClick={handleShowRoles}>
+      <S.RoleEditButton color="gray_1" bg="white" onClick={openRoleSelectPopup}>
         {currentRelation}
       </S.RoleEditButton>
-      {isShowRoles && (
-        <>
-          {notSelectedRelation.map((item, idx) => (
-            <S.RoleEditButton
-              key={idx}
-              color="gray_3"
-              bg="gray_4"
-              onClick={() => handleSelectedRelation(item.type)}
-            >
-              {item.relation}
-            </S.RoleEditButton>
-          ))}
-        </>
-      )}
     </>
   );
 };

--- a/src/components/Member/MyPage/Buttons/SaveButton.tsx
+++ b/src/components/Member/MyPage/Buttons/SaveButton.tsx
@@ -72,12 +72,7 @@ const SaveButton = () => {
       memberProfileUri: s3ProfileData[0] || memberProfileUri
     };
 
-    mutateProfileInfo(requestData, {
-      onSuccess() {
-        // 요청 성공 시 defaultValues로 초기화
-        reset();
-      }
-    });
+    mutateProfileInfo(requestData);
   };
 
   useEffect(() => {

--- a/src/components/Member/MyPage/Cards/styles.ts
+++ b/src/components/Member/MyPage/Cards/styles.ts
@@ -12,7 +12,7 @@ export const Card = styled.div`
   position: relative;
   border-radius: 16px;
   width: 100%;
-  max-width: 11rem; //176px
+  min-width: 11rem; //176px
   height: 0;
   padding-bottom: 216px;
 `;

--- a/src/components/Member/MyPage/Cards/styles.ts
+++ b/src/components/Member/MyPage/Cards/styles.ts
@@ -12,7 +12,7 @@ export const Card = styled.div`
   position: relative;
   border-radius: 16px;
   width: 100%;
-  min-width: 11rem; //176px
+  max-width: 11rem; //176px
   height: 0;
   padding-bottom: 216px;
 `;

--- a/src/components/Member/MyPage/Container/styles.ts
+++ b/src/components/Member/MyPage/Container/styles.ts
@@ -3,6 +3,10 @@ import styled from "styled-components";
 
 import type { ColorKeys } from "styles/types";
 
+export const LayoutContainer = styled(Layout)`
+  height: calc(100% - 78px); // Layout height -48px 제거
+`;
+
 export const PageContainer = styled.div.withConfig({
   shouldForwardProp: (prop) => !["pt", "imageUrl", "backgroundColor"].includes(prop)
 })<{
@@ -22,8 +26,4 @@ export const PageContainer = styled.div.withConfig({
   &::-webkit-scrollbar {
     display: none;
   }
-`;
-
-export const LayoutContainer = styled(Layout)`
-  height: 100%;
 `;

--- a/src/components/Member/MyPage/MyDogInfo/styles.ts
+++ b/src/components/Member/MyPage/MyDogInfo/styles.ts
@@ -21,9 +21,13 @@ export const DeleteDogButton = styled.button`
 `;
 
 export const MyDogInfoList = styled.section`
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: 0.75rem;
   padding: 0 1rem;
+  & > div {
+    min-width: 100%;
+  }
 `;
 
 export const DragCarouselWrapper = styled.div`

--- a/src/components/Member/MyPage/MyMemberInfoEdit/MyProfileEdit.tsx
+++ b/src/components/Member/MyPage/MyMemberInfoEdit/MyProfileEdit.tsx
@@ -3,7 +3,6 @@ import { FILE_NAME, TYPE_NAME } from "constants/s3File";
 
 import { TextInput } from "components/common";
 import ProfileUploadBox from "components/Member/Profile/Box/ProfileUploadBox";
-import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { css } from "styled-components";
 
@@ -12,13 +11,9 @@ import RoleEditButton from "../Buttons/RoleEditButton";
 
 const MyProfileEdit = () => {
   const { register } = useFormContext();
-  const [isShowRoles, setIsShowRoles] = useState(false);
-  const handleShowRoles = () => {
-    setIsShowRoles((prev) => !prev);
-  };
 
   return (
-    <S.MyProfileWrapper isShowRoles={isShowRoles}>
+    <S.MyProfileWrapper>
       <S.ProfileBox>
         <ProfileUploadBox type={TYPE_NAME.MEMBER} fileName={FILE_NAME.PROFILE_MEMBER} mode="edit" />
       </S.ProfileBox>
@@ -32,7 +27,7 @@ const MyProfileEdit = () => {
         />
         의
       </S.MyDogName>
-      <RoleEditButton isShowRoles={isShowRoles} handleShowRoles={handleShowRoles} />
+      <RoleEditButton />
     </S.MyProfileWrapper>
   );
 };

--- a/src/components/Member/MyPage/MyMemberInfoEdit/styles.ts
+++ b/src/components/Member/MyPage/MyMemberInfoEdit/styles.ts
@@ -3,16 +3,17 @@ import { styled } from "styled-components";
 export const MyProfileWrapper = styled.section`
   position: relative;
   display: grid;
-  grid-template-columns: repeat(3, minmax(112px, auto));
-  gap: 12px 4px;
+  grid-template-columns: repeat(2, minmax(112px, auto));
+  gap: 0.75rem 0.9375rem;
   justify-content: center;
-  margin-bottom: 82px;
+  margin-bottom: 5.125rem;
+  padding: 0 1.25rem;
 `;
 
 export const ProfileEditWrapper = styled.section`
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 2rem;
 `;
 
 export const ProfileBox = styled.div`
@@ -26,7 +27,7 @@ export const ProfileEditBox = styled.div`
   position: relative;
   width: 107px;
   height: 0;
-  padding-bottom: 107px;
+  padding-bottom: 6.6875rem;
 `;
 
 export const UserImage = styled.img`
@@ -55,7 +56,7 @@ export const ProfileEditButton = styled.button`
 
 export const MyDogName = styled.div`
   display: flex;
-  gap: 8px;
+  gap: 0.5rem;
   align-items: center;
   color: ${({ theme }) => theme.colors.gray_1};
   ${({ theme }) => theme.typo.body2_16_R};

--- a/src/components/Member/MyPage/MyMemberInfoEdit/styles.ts
+++ b/src/components/Member/MyPage/MyMemberInfoEdit/styles.ts
@@ -1,17 +1,12 @@
 import { styled } from "styled-components";
-interface MyInfoEditProps {
-  isShowRoles?: boolean;
-}
 
-export const MyProfileWrapper = styled.section.withConfig({
-  shouldForwardProp: (prop) => prop !== "isShowRoles"
-})<MyInfoEditProps>`
+export const MyProfileWrapper = styled.section`
   position: relative;
   display: grid;
   grid-template-columns: repeat(3, minmax(112px, auto));
   gap: 12px 4px;
   justify-content: center;
-  margin-bottom: ${(props) => (props.isShowRoles ? "21px" : "82px")};
+  margin-bottom: 82px;
 `;
 
 export const ProfileEditWrapper = styled.section`

--- a/src/components/Member/MyPage/MyMemberinfo/index.tsx
+++ b/src/components/Member/MyPage/MyMemberinfo/index.tsx
@@ -43,7 +43,7 @@ const MyInfo = () => {
             </S.IconCircle>
             이름
           </S.MyInfoTitle>
-          <S.MyInfoText>{data.memberName ? data.memberName : ""}</S.MyInfoText>
+          <S.MyInfoText>{data.memberName ?? ""}</S.MyInfoText>
         </S.MyInfoItem>
         <S.MyInfoItem>
           <S.MyInfoTitle>
@@ -58,7 +58,7 @@ const MyInfo = () => {
             </S.IconCircle>
             성별
           </S.MyInfoTitle>
-          <S.MyInfoText>{data.memberGender ? GENDER_DATA[data.memberGender] : ""}</S.MyInfoText>
+          <S.MyInfoText>{data.memberGender ?? ""}</S.MyInfoText>
         </S.MyInfoItem>
         <S.MyInfoItem>
           <S.MyInfoTitle>
@@ -73,7 +73,7 @@ const MyInfo = () => {
             </S.IconCircle>
             연락처
           </S.MyInfoTitle>
-          <S.MyInfoText>{data.phoneNumber ? data.phoneNumber : ""}</S.MyInfoText>
+          <S.MyInfoText>{data.phoneNumber ?? ""}</S.MyInfoText>
         </S.MyInfoItem>
         <S.MyInfoItem>
           <S.MyInfoTitle>
@@ -88,7 +88,7 @@ const MyInfo = () => {
             </S.IconCircle>
             비상연락처
           </S.MyInfoTitle>
-          <S.MyInfoText>{data.emergencyPhoneNumber ? data.emergencyPhoneNumber : ""}</S.MyInfoText>
+          <S.MyInfoText>{data.emergencyPhoneNumber ?? ""}</S.MyInfoText>
         </S.MyInfoItem>
         <S.MyInfoItem className="address">
           <S.MyInfoTitle>
@@ -104,7 +104,7 @@ const MyInfo = () => {
             주소
           </S.MyInfoTitle>
           <S.MyInfoText>
-            {data.addressDetail && data.address ? `${data.addressDetail} ${data.address}` : ""}
+            {data.addressDetail && data.address ? `${data.address} ${data.addressDetail}` : ""}
           </S.MyInfoText>
         </S.MyInfoItem>
       </S.MyInfoList>

--- a/src/components/Member/MyPage/Setting/AlertSetting/context/AlertSettingProvider.tsx
+++ b/src/components/Member/MyPage/Setting/AlertSetting/context/AlertSettingProvider.tsx
@@ -1,0 +1,54 @@
+import { createContext, PropsWithChildren, useContext, useState } from "react";
+
+type AlertSettings = {
+  careDog: boolean;
+  activity: boolean;
+};
+
+interface AlertSettingProps {
+  alertSettings: AlertSettings;
+  isAllOn: boolean;
+  toggleAll: () => void;
+  toggleIndividual: (key: keyof AlertSettings) => void;
+}
+
+export const AlertSettingContext = createContext<AlertSettingProps | null>(null);
+
+export const AlertSettingProvider = ({ children }: PropsWithChildren) => {
+  // FIXME 알림 여부 api 추가 필요
+  const [alertSettings, setAlertSettings] = useState({
+    careDog: false,
+    activity: false
+  });
+
+  const isAllOn = Object.values(alertSettings).every(Boolean);
+
+  const toggleAll = () => {
+    const newState = !isAllOn;
+    setAlertSettings({
+      careDog: newState,
+      activity: newState
+    });
+  };
+
+  const toggleIndividual = (key: keyof AlertSettings) => {
+    setAlertSettings((prev) => ({
+      ...prev,
+      [key]: !prev[key]
+    }));
+  };
+
+  return (
+    <AlertSettingContext.Provider value={{ alertSettings, isAllOn, toggleAll, toggleIndividual }}>
+      {children}
+    </AlertSettingContext.Provider>
+  );
+};
+
+export const useAlertSetting = () => {
+  const context = useContext(AlertSettingContext);
+  if (!context) {
+    throw new Error("useAlertSetting must be used within a AlertSettingProvider");
+  }
+  return context;
+};

--- a/src/components/Member/MyPage/Setting/AlertSetting/index.tsx
+++ b/src/components/Member/MyPage/Setting/AlertSetting/index.tsx
@@ -46,7 +46,7 @@ const AlertSetting = ({ setStep, role }: AlertSettingProps) => {
           <Toggle isOn={isAllOn} onToggle={toggleAll} />
         </S.TopWrapper>
         <S.SettingList>
-          {alretItem(<DogIcon />, "등록 알림1", "강아지 등록 정보, 이용권, 유의사항 등", "careDog")}
+          {alretItem(<DogIcon />, "등록 알림", "강아지 등록 정보, 이용권, 유의사항 등", "careDog")}
           {alretItem(<FootRoundIcon />, "활동 알림", "알림장, 채팅, 사진", "activity")}
         </S.SettingList>
       </Box>

--- a/src/components/Member/MyPage/Setting/AlertSetting/index.tsx
+++ b/src/components/Member/MyPage/Setting/AlertSetting/index.tsx
@@ -1,0 +1,57 @@
+import DogIcon from "assets/svg/dog-icon";
+import FootRoundIcon from "assets/svg/foot-round-icon";
+import { Box } from "components/common";
+import Header from "components/common/Header";
+import Toggle from "components/common/Toggle/Toggle";
+import { Role } from "types/common/role.types";
+
+import { useAlertSetting } from "./context/AlertSettingProvider";
+import * as S from "./styles";
+
+interface AlertSettingProps {
+  setStep: (step: number) => void;
+  role: Role;
+}
+
+type AlertSettings = {
+  careDog: boolean;
+  activity: boolean;
+};
+
+const AlertSetting = ({ setStep, role }: AlertSettingProps) => {
+  const { alertSettings, isAllOn, toggleAll, toggleIndividual } = useAlertSetting();
+
+  const alretItem = (icon: any, text: string, subText: string, stateKey: keyof AlertSettings) => (
+    <S.SettingItem type="notification" margintop="0.5rem">
+      <S.TextWrapper>
+        <S.TextBox>
+          <S.StyledIconBox>{icon}</S.StyledIconBox>
+          <S.Text>{text}</S.Text>
+        </S.TextBox>
+        <S.SubTextPL>{subText}</S.SubTextPL>
+      </S.TextWrapper>
+      <Toggle isOn={alertSettings[stateKey]} onToggle={() => toggleIndividual(stateKey)} />
+    </S.SettingItem>
+  );
+
+  return (
+    <>
+      <Header type="text" text="설정" handleClick={() => setStep(0)} />
+      <Box mt={5} bg={"white"} height={"100%"}>
+        <S.TopWrapper>
+          <div>
+            <S.Title>서비스 알림</S.Title>
+            <S.SubTitle>서비스 전체 알림</S.SubTitle>
+          </div>
+          <Toggle isOn={isAllOn} onToggle={toggleAll} />
+        </S.TopWrapper>
+        <S.SettingList>
+          {alretItem(<DogIcon />, "등록 알림1", "강아지 등록 정보, 이용권, 유의사항 등", "careDog")}
+          {alretItem(<FootRoundIcon />, "활동 알림", "알림장, 채팅, 사진", "activity")}
+        </S.SettingList>
+      </Box>
+    </>
+  );
+};
+
+export default AlertSetting;

--- a/src/components/Member/MyPage/Setting/AlertSetting/styles.ts
+++ b/src/components/Member/MyPage/Setting/AlertSetting/styles.ts
@@ -1,0 +1,107 @@
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+interface ISettingProps {
+  type?: string;
+  margintop?: string;
+}
+
+export const SettingList = styled.ul``;
+
+export const SettingItem = styled.li<ISettingProps>`
+  padding: 1rem 1rem 1rem 1.5rem;
+  display: flex;
+  flex-direction: ${(props) => (props.type === "verUpdate" ? "column" : "row")};
+  justify-content: ${(props) => (props.type === "notification" ? "space-between" : "normal")};
+  background-color: ${({ theme }) => theme.colors.white};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.gray_5};
+  ${({ theme }) => theme.typo.label1_16_M};
+  color: ${({ theme }) => theme.colors.gray_1};
+  margin-top: ${(props) => props.margintop && props.margintop};
+`;
+
+export const TopWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem;
+  padding-bottom: 0;
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const TopBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const ButtomBox = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const TextBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+`;
+
+// TODO 추후 공통 컴포넌트 작업 필요합니다.
+export const StyledIconBox = styled.div`
+  display: flex;
+  width: 24px;
+  height: 24px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50px;
+  background-color: ${({ theme }) => theme.colors.yellow_3};
+`;
+
+export const Title = styled.p`
+  ${({ theme }) => theme.typo.body1_18_B}
+  color: ${({ theme }) => theme.colors.gray_1};
+`;
+
+export const SubTitle = styled.span`
+  ${({ theme }) => theme.typo.body2_16_R}
+  color: ${({ theme }) => theme.colors.gray_2};
+`;
+
+export const Text = styled.span`
+  ${({ theme }) => theme.typo.label1_16_M};
+  color: ${({ theme }) => theme.colors.gray_1};
+`;
+
+export const SubTextPL = styled.span`
+  ${({ theme }) => theme.typo.caption1_12_R};
+  color: ${({ theme }) => theme.colors.gray_2};
+  padding-left: 1.75rem;
+`;
+
+export const SubText = styled.span<ISettingProps>`
+  ${({ theme }) => theme.typo.caption1_12_R};
+  color: ${(props) =>
+    props.type === "verUpdate"
+      ? ({ theme }) => theme.colors.primaryColor
+      : ({ theme }) => theme.colors.gray_2};
+`;
+
+export const GotoPageButton = styled(Link)`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.3125rem;
+  width: 100%;
+`;
+
+export const GotoUpdateButton = styled.button`
+  ${({ theme }) => theme.typo.caption1_12_B};
+  background-color: ${({ theme }) => theme.colors.primaryColor};
+  color: ${({ theme }) => theme.colors.white};
+  border-radius: 50px;
+  font-weight: 700;
+  padding: 0 0.5rem;
+`;

--- a/src/components/Member/MyPage/Setting/DeleteAccount/index.tsx
+++ b/src/components/Member/MyPage/Setting/DeleteAccount/index.tsx
@@ -1,0 +1,145 @@
+import { routes } from "constants/path";
+
+import { Box, Checkbox, Flex, Layout, Text } from "components/common";
+import { BottomButton } from "components/common/Button";
+import Header from "components/common/Header";
+import { useDeleteMember } from "hooks/api/member/member";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Role } from "types/common/role.types";
+
+interface DeleteAccountProps {
+  setStep: (step: number) => void;
+  role: string;
+}
+
+type ContentCheck = {
+  1: boolean;
+  2: boolean;
+  3: boolean;
+  4: boolean;
+};
+
+const DeleteAccount = ({ setStep, role }: DeleteAccountProps) => {
+  const { mutateDeleteMember } = useDeleteMember();
+  const navigate = useNavigate();
+  const [contents, setContents] = useState({
+    1: false,
+    2: false,
+    3: false,
+    4: false
+  });
+
+  const isAllChecked =
+    role === Role.ROLE_MEMBER || role === Role.ROLE_GUEST
+      ? Object.values(contents).every(Boolean)
+      : contents[1] && contents[2] && contents[3];
+
+  const checkAll = () => {
+    const newState = !isAllChecked;
+    setContents({
+      1: newState,
+      2: newState,
+      3: newState,
+      4: newState
+    });
+  };
+
+  const checkIndividual = (key: keyof ContentCheck) => {
+    setContents((prev) => ({
+      ...prev,
+      [key]: !prev[key]
+    }));
+  };
+
+  const onSubmit = () => {
+    if (isAllChecked) {
+      // mutateDeleteMember; // FIXME 탈퇴 기능 추가 필요
+      navigate(routes.unregister.success.root);
+    }
+    return;
+  };
+
+  const renderCheckboxItem = (key: keyof ContentCheck, text: string, marginTop: number) => (
+    <Box
+      width="100%"
+      border={1}
+      borderRadius={8}
+      borderColor={contents[key] ? "transparent" : "gray_4"}
+      backgroundColor={contents[key] ? "br_5" : "transparent"}
+      padding={12}
+      marginTop={marginTop}
+    >
+      <Checkbox
+        onChange={() => checkIndividual(key)}
+        isChecked={contents[key]}
+        variant="default"
+        label={
+          <Text color="gray_1">
+            {text.split(/(<.*?>)/g).map((segment, index) =>
+              /<.*?>/.test(segment) ? (
+                <Text key={index} color="primaryColor">
+                  {segment.replace(/<|>/g, "")}
+                </Text>
+              ) : (
+                segment
+              )
+            )}
+          </Text>
+        }
+      />
+    </Box>
+  );
+
+  return (
+    <>
+      <Header type="back" handleClick={() => setStep(0)} shadow={true} />
+      <Layout type="detail" paddingTop="1.5rem" paddingX="1rem">
+        <Flex direction="column" gap={3}>
+          <Text as="p" typo="title1_24_B">
+            똑독 탈퇴를 원하시나요?
+          </Text>
+          <Text as="p" color="gray_2">
+            탈퇴 전, 아래 내용을 확인해 주세요
+          </Text>
+        </Flex>
+        {renderCheckboxItem(
+          1,
+          "지금까지 주고받은 채팅내역, 알림장, 사진앨범 등의 모든  활동 기록이 <영구 삭제>되며 복구할 수 없어요",
+          30
+        )}
+        {renderCheckboxItem(
+          2,
+          "탈퇴 후 사용했던 소셜 아이디로 <재가입 시 신규 회원으로 가입> 돼요",
+          15
+        )}
+        {renderCheckboxItem(3, "계정 삭제 후 <7일>간 다시 가입할 수 없어요", 15)}
+        <Box
+          width="100%"
+          border={1}
+          borderRadius={8}
+          borderColor={`${isAllChecked ? "transparent" : "gray_4"}`}
+          backgroundColor={`${isAllChecked ? "br_4" : "transparent"}`}
+          padding={12}
+          marginTop={60}
+        >
+          <Checkbox
+            onChange={checkAll}
+            isChecked={isAllChecked}
+            variant="default"
+            label={
+              <Text color={`${isAllChecked ? "primaryColor" : "gray_1"}`}>
+                위 안내사항에 모두 동의해요
+              </Text>
+            }
+          />
+        </Box>
+        <BottomButton onClick={onSubmit} disabled={!isAllChecked}>
+          탈퇴하기
+        </BottomButton>
+      </Layout>
+    </>
+  );
+};
+
+export default DeleteAccount;

--- a/src/components/Member/MyPage/Setting/DeleteAccount/index.tsx
+++ b/src/components/Member/MyPage/Setting/DeleteAccount/index.tsx
@@ -64,34 +64,36 @@ const DeleteAccount = ({ setStep, role }: DeleteAccountProps) => {
   };
 
   const renderCheckboxItem = (key: keyof ContentCheck, text: string, marginTop: number) => (
-    <Box
-      width="100%"
-      border={1}
-      borderRadius={8}
-      borderColor={contents[key] ? "transparent" : "gray_4"}
-      backgroundColor={contents[key] ? "br_5" : "white"}
-      padding={12}
-      marginTop={marginTop}
-    >
-      <Checkbox
-        onChange={() => checkIndividual(key)}
-        isChecked={contents[key]}
-        variant="default"
-        label={
-          <Text color="gray_1">
-            {text.split(/(<.*?>)/g).map((segment, index) =>
-              /<.*?>/.test(segment) ? (
-                <Text key={index} color="primaryColor">
-                  {segment.replace(/<|>/g, "")}
-                </Text>
-              ) : (
-                segment
-              )
-            )}
-          </Text>
-        }
-      />
-    </Box>
+    <S.CheckboxWrapper>
+      <Box
+        width="100%"
+        border={1}
+        borderRadius={8}
+        borderColor={contents[key] ? "transparent" : "gray_4"}
+        backgroundColor={contents[key] ? "br_5" : "white"}
+        padding={12}
+        marginTop={marginTop}
+      >
+        <Checkbox
+          onChange={() => checkIndividual(key)}
+          isChecked={contents[key]}
+          variant="default"
+          label={
+            <Text color="gray_1">
+              {text.split(/(<.*?>)/g).map((segment, index) =>
+                /<.*?>/.test(segment) ? (
+                  <Text key={index} color="primaryColor">
+                    {segment.replace(/<|>/g, "")}
+                  </Text>
+                ) : (
+                  segment
+                )
+              )}
+            </Text>
+          }
+        />
+      </Box>
+    </S.CheckboxWrapper>
   );
 
   return (
@@ -117,26 +119,29 @@ const DeleteAccount = ({ setStep, role }: DeleteAccountProps) => {
           15
         )}
         {renderCheckboxItem(3, "계정 삭제 후 <7일>간 다시 가입할 수 없어요", 15)}
-        <Box
-          width="100%"
-          border={1}
-          borderRadius={8}
-          borderColor={`${isAllChecked ? "transparent" : "gray_4"}`}
-          backgroundColor={`${isAllChecked ? "br_4" : "white"}`}
-          padding={12}
-          marginTop={60}
-        >
-          <Checkbox
-            onChange={checkAll}
-            isChecked={isAllChecked}
-            variant="default"
-            label={
-              <Text color={`${isAllChecked ? "primaryColor" : "gray_1"}`}>
-                위 안내사항에 모두 동의해요
-              </Text>
-            }
-          />
-        </Box>
+        <S.CheckboxWrapper>
+          <Box
+            width="100%"
+            border={1}
+            borderRadius={8}
+            borderColor={`${isAllChecked ? "transparent" : "gray_4"}`}
+            backgroundColor={`${isAllChecked ? "br_4" : "white"}`}
+            padding={12}
+            marginTop={60}
+          >
+            <Checkbox
+              onChange={checkAll}
+              isChecked={isAllChecked}
+              variant="default"
+              label={
+                <Text color={`${isAllChecked ? "primaryColor" : "gray_1"}`}>
+                  위 안내사항에 모두 동의해요
+                </Text>
+              }
+            />
+          </Box>
+        </S.CheckboxWrapper>
+
         <BottomButton onClick={onSubmit} disabled={!isAllChecked}>
           탈퇴하기
         </BottomButton>

--- a/src/components/Member/MyPage/Setting/DeleteAccount/index.tsx
+++ b/src/components/Member/MyPage/Setting/DeleteAccount/index.tsx
@@ -1,5 +1,6 @@
 import { routes } from "constants/path";
 
+import ExclamationMarkIcon from "assets/svg/exclamationMark-icon";
 import { Box, Checkbox, Flex, Layout, Text } from "components/common";
 import { BottomButton } from "components/common/Button";
 import Header from "components/common/Header";
@@ -7,6 +8,8 @@ import { useDeleteMember } from "hooks/api/member/member";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Role } from "types/common/role.types";
+
+import * as S from "./styles";
 
 interface DeleteAccountProps {
   setStep: (step: number) => void;
@@ -66,7 +69,7 @@ const DeleteAccount = ({ setStep, role }: DeleteAccountProps) => {
       border={1}
       borderRadius={8}
       borderColor={contents[key] ? "transparent" : "gray_4"}
-      backgroundColor={contents[key] ? "br_5" : "transparent"}
+      backgroundColor={contents[key] ? "br_5" : "white"}
       padding={12}
       marginTop={marginTop}
     >
@@ -119,7 +122,7 @@ const DeleteAccount = ({ setStep, role }: DeleteAccountProps) => {
           border={1}
           borderRadius={8}
           borderColor={`${isAllChecked ? "transparent" : "gray_4"}`}
-          backgroundColor={`${isAllChecked ? "br_4" : "transparent"}`}
+          backgroundColor={`${isAllChecked ? "br_4" : "white"}`}
           padding={12}
           marginTop={60}
         >
@@ -137,6 +140,9 @@ const DeleteAccount = ({ setStep, role }: DeleteAccountProps) => {
         <BottomButton onClick={onSubmit} disabled={!isAllChecked}>
           탈퇴하기
         </BottomButton>
+        <S.ExclamationMark>
+          <ExclamationMarkIcon />
+        </S.ExclamationMark>
       </Layout>
     </>
   );

--- a/src/components/Member/MyPage/Setting/DeleteAccount/styles.ts
+++ b/src/components/Member/MyPage/Setting/DeleteAccount/styles.ts
@@ -13,3 +13,9 @@ export const ExclamationMark = styled.div`
   background-color: ${({ theme }) => theme.colors.gray_5};
   z-index: -1;
 `;
+
+export const CheckboxWrapper = styled.div`
+  & > div > label > span:first-of-type {
+    flex-shrink: 0;
+  }
+`;

--- a/src/components/Member/MyPage/Setting/DeleteAccount/styles.ts
+++ b/src/components/Member/MyPage/Setting/DeleteAccount/styles.ts
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+
+export const ExclamationMark = styled.div`
+  position: absolute;
+  right: -2rem;
+  bottom: 5.8125rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 100%;
+  width: 236px;
+  height: 236px;
+  background-color: ${({ theme }) => theme.colors.gray_5};
+  z-index: -1;
+`;

--- a/src/components/Member/MyPage/Setting/PolicySetting/index.tsx
+++ b/src/components/Member/MyPage/Setting/PolicySetting/index.tsx
@@ -1,0 +1,43 @@
+import { Layout, Text } from "components/common";
+import Header from "components/common/Header";
+
+interface PolicySettingProps {
+  setStep: (step: number) => void;
+}
+
+const PolicySetting = ({ setStep }: PolicySettingProps) => {
+  return (
+    <>
+      <Header type="text" text="정책" handleClick={() => setStep(0)} />
+      <Layout type="detail" paddingTop="1.5rem" paddingX="1rem">
+        <Text typo="label2_14_R" color="gray_1">
+          App Store의 기본 원칙은 간단합니다. 사용자에게는 안전하게 앱을 이용할 수 있는 경험,
+          개발자에게는 뛰어난 앱을 개발할 수 있는 훌륭한 기회를 제공하는 것입니다. 이를 위해
+          Apple에서는 모든 콘텐츠를 세심하게 엄선한 App Store를 제공합니다. App Store의 모든 앱은
+          전문가들이 심사하고 에디터 팀은 사용자가 매일 새로운 앱을 발견하도록 콘텐츠를 작성합니다.
+          그 외 모든 것은 언제든 인터넷을 사용하면 됩니다. App Store 모델 및 지침이 여러분의 앱 또는
+          비즈니스 아이디어에 적합하지 않다면, 뛰어난 웹 환경을 제공하는 Safari를 통해서도 여러분의
+          서비스를 제공할 수 있습니다. 랫폼을 구축하기 위해 최선을 다하고 있습니다.
+          <br />
+          <br />
+          App Store의 기본 원칙은 간단합니다. 사용자에게는 안전하게 앱을 이용할 수 있는 경험,
+          개발자에게는 뛰어난 앱을 개발할 수 있는 훌륭한 기회를 제공하는 것입니다. 이를 위해
+          Apple에서는 모든 콘텐츠를 세심하게 엄선한 App Store를 제공합니다. App Store의 모든 앱은
+          전문가들이 심사하고 에디터 팀은 사용자가 매일 새로운 앱을 발견하도록 콘텐츠를 작성합니다.
+          그 외 모든 것은 언제든 인터넷을 사용하면 됩니다. App Store 모델 및 지침이 여러분의 앱 또는
+          비즈니스 아이디어에 적합하지 않다면, 뛰어난 웹 환경을 제공하는 Safari를 통해서도 여러분의
+          서비스를 제공할 수 있습니다. 랫폼을 구축하기 위해 최선을 다하고 있습니다.App Store의 기본
+          원칙은 간단합니다. 사용자에게는 안전하게 앱을 이용할 수 있는 경험, 개발자에게는 뛰어난
+          앱을 개발할 수 있는 훌륭한 기회를 제공하는 것입니다. 이를 위해 Apple에서는 모든 콘텐츠를
+          세심하게 엄선한 App Store를 제공합니다. App Store의 모든 앱은 전문가들이 심사하고 에디터
+          팀은 사용자가 매일 새로운 앱을 발견하도록 콘텐츠를 작성합니다. 그 외 모든 것은 언제든
+          인터넷을 사용하면 됩니다. App Store 모델 및 지침이 여러분의 앱 또는 비즈니스 아이디어에
+          적합하지 않다면, 뛰어난 웹 환경을 제공하는 Safari를 통해서도 여러분의 서비스를 제공할 수
+          있습니다. 랫폼을 구축하기 위해 최선을 다하고 있습니다.
+        </Text>
+      </Layout>
+    </>
+  );
+};
+
+export default PolicySetting;

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -38,6 +38,7 @@ interface Props {
   rightElement?: React.ReactNode;
   transparent?: boolean;
   shadow?: boolean;
+  position?: "absolute" | "relative"; // 기본 fixed
 }
 
 const Header = ({
@@ -47,7 +48,8 @@ const Header = ({
   text,
   rightElement,
   transparent,
-  shadow
+  shadow,
+  position
 }: Props) => {
   const navigate = useNavigate();
   // const { data } = useGetNewAlarm(Number(adminId));
@@ -56,7 +58,7 @@ const Header = ({
   const click = handleClick ? handleClick : () => navigate(-1);
   return (
     <>
-      <Container className={transparent ? "transparent" : ""}>
+      <Container className={`${transparent ? "transparent" : ""} ${position ? position : ""}`}>
         <HeaderWrapper className={transparent || shadow ? "transparent" : ""}>
           {type === "main" && (
             <TextWrapper>

--- a/src/components/common/Header/styles.ts
+++ b/src/components/common/Header/styles.ts
@@ -12,8 +12,17 @@ export const Container = styled.div`
   align-items: center;
   background-color: ${(props) => props.theme.colors.white};
   z-index: 5;
+
   &.transparent {
     background-color: transparent;
+  }
+
+  &.absolute {
+    position: absolute;
+  }
+
+  &.relative {
+    position: relative;
   }
 `;
 

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -184,6 +184,14 @@ const member = {
   /** 마이페이지 */
   mypage: {
     root: `/mypage`,
+    /** 설정 페이지 */
+    setting: {
+      root: `/setting`
+    },
+    /** 계정 탈퇴 완료 */
+    deleteComplete: {
+      root: `/mypage/delete-complete`
+    },
     /** 프로필 */
     profile: {
       root: `/mypage/profile`,

--- a/src/hooks/api/member/member.ts
+++ b/src/hooks/api/member/member.ts
@@ -115,11 +115,16 @@ export const useGetMemberProfileInfo = () => {
 
 // 마이페이지 - 견주 프로필 수정
 export const usePostMemberProfileInfo = () => {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { mutate } = useMutation({
     mutationFn: (req: IMemberProfilePostInfo) => handleMemberInfoResult(req),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEY.MEMBER_PROFILE_INFO });
+      navigate(routes.member.mypage.profile.root);
+      setTimeout(() => {
+        showToast("수정이 완료되었습니다.", "bottom");
+      }, 100);
     },
     onError: () => {
       showToast("실패했습니다. 다시 시도해주세요", "bottom");

--- a/src/hooks/api/member/member.ts
+++ b/src/hooks/api/member/member.ts
@@ -169,6 +169,10 @@ export const usePostMemberDogDelete = () => {
     mutationFn: (dogId: string) => handlePostMemberDogDelete(dogId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEY.MEMBER_MYPAGE_MAIN_INFO });
+      showToast("강아지가 삭제되었습니다", "bottom");
+    },
+    onError: () => {
+      showToast("실패했습니다. 다시 시도해주세요", "bottom");
     }
   });
 

--- a/src/hooks/api/member/member.ts
+++ b/src/hooks/api/member/member.ts
@@ -22,16 +22,15 @@ import {
   handlePostMemoDogAllergy,
   handlePostMemoDogPickdrop,
   handlePostDogProfile,
-  handleCancelMemberEnrollment
+  handleCancelMemberEnrollment,
+  handleDeleteMember
 } from "apis/member/member.api";
-import useLogout from "hooks/common/useLogout";
 import { Adapter, DogInfoFormAdapter } from "libs/adapters";
 import { useNavigate } from "react-router-dom";
 import { getLabelForValue } from "utils/formatter";
 import showToast from "utils/showToast";
 
 import type {
-  HomeDataType,
   IMemberProfile,
   IMemberProfilePostInfo,
   MemberDogInfoData,
@@ -313,4 +312,13 @@ export const usePostDogProfile = (dogId: number) => {
   });
 
   return { mutateDogProfile: mutate };
+};
+
+//회원 탈퇴
+export const useDeleteMember = () => {
+  const { mutate } = useMutation({
+    mutationFn: handleDeleteMember
+  });
+
+  return { mutateDeleteMember: mutate };
 };

--- a/src/pages/AdminMyPage/AdminDeleteCompletePage.tsx
+++ b/src/pages/AdminMyPage/AdminDeleteCompletePage.tsx
@@ -2,10 +2,17 @@ import { routes } from "constants/path";
 
 import { Layout, Text } from "components/common";
 import { BottomButton } from "components/common/Button";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 const AdminDeleteCompletePage = () => {
   const navigate = useNavigate();
+
+  useEffect(() => {
+    setTimeout(() => {
+      navigate(routes.login.root);
+    }, 3000);
+  }, []);
 
   return (
     <>

--- a/src/pages/AdminMyPage/AdminDeleteCompletePage.tsx
+++ b/src/pages/AdminMyPage/AdminDeleteCompletePage.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from "react-router-dom";
 const AdminDeleteCompletePage = () => {
   const navigate = useNavigate();
 
+  // 3초 이상 머물 경우 강제로 로그인 화면으로 이동
   useEffect(() => {
     setTimeout(() => {
       navigate(routes.login.root);

--- a/src/pages/MemberPage/MemberMyInfoEditPage.tsx
+++ b/src/pages/MemberPage/MemberMyInfoEditPage.tsx
@@ -6,7 +6,7 @@ import MyInfoEdit from "components/Member/MyPage/MyMemberInfoEdit/MyInfoEdit";
 import MyProfileEdit from "components/Member/MyPage/MyMemberInfoEdit/MyProfileEdit";
 import { ContentContainer } from "components/Member/MyPage/styles";
 import { useGetMemberProfileInfo } from "hooks/api/member/member";
-import { FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useForm, useFormState } from "react-hook-form";
 import { useBlocker } from "react-router-dom";
 
 const MemberMyInfoEditPage = () => {
@@ -18,7 +18,8 @@ const MemberMyInfoEditPage = () => {
     defaultValues: { ...memberData, profileUri: memberProfileUri }
   });
 
-  const blocker = useBlocker(() => methods.formState.isDirty);
+  const { isSubmitSuccessful } = useFormState({ control: methods.control });
+  const blocker = useBlocker(() => !isSubmitSuccessful && methods.formState.isDirty);
 
   return (
     <>

--- a/src/pages/MemberPage/MemberMyPage.tsx
+++ b/src/pages/MemberPage/MemberMyPage.tsx
@@ -1,21 +1,21 @@
 import placeholderImg from "assets/images/placeholder-dog.png";
-import { Layout } from "components/common";
 import Header from "components/common/Header";
 import { NavBar } from "components/common/NavBar";
 import LogOutButton from "components/Member/MyPage/Buttons/LogOutButton";
-import { PageContainer } from "components/Member/MyPage/Container/styles";
+import { LayoutContainer, PageContainer } from "components/Member/MyPage/Container/styles";
 import MemberProfile from "components/Member/MyPage/MemberProfile";
 import MyDogInfo from "components/Member/MyPage/MyDogInfo";
 import { CardContainer, ContentContainer } from "components/Member/MyPage/styles";
 import { useGetMemberInfo } from "hooks/api/member/member";
+
 const MemberMyPage = () => {
   const { data } = useGetMemberInfo();
 
   return (
     <>
-      <Header type="setting" text="마이페이지" transparent />
-      <Layout type="main">
-        <PageContainer pt="4" imageUrl={data.memberProfileUri ?? placeholderImg}>
+      <LayoutContainer type="main">
+        <PageContainer pt="1" imageUrl={data.memberProfileUri ?? placeholderImg}>
+          <Header type="setting" text="마이페이지" position="absolute" transparent />
           <ContentContainer>
             <MemberProfile data={data} />
             <CardContainer>
@@ -25,7 +25,7 @@ const MemberMyPage = () => {
         </PageContainer>
         <LogOutButton />
         <NavBar />
-      </Layout>
+      </LayoutContainer>
     </>
   );
 };

--- a/src/pages/MemberPage/MemberMyPage.tsx
+++ b/src/pages/MemberPage/MemberMyPage.tsx
@@ -1,3 +1,5 @@
+import { routes } from "constants/path";
+
 import placeholderImg from "assets/images/placeholder-dog.png";
 import Header from "components/common/Header";
 import { NavBar } from "components/common/NavBar";
@@ -7,15 +9,23 @@ import MemberProfile from "components/Member/MyPage/MemberProfile";
 import MyDogInfo from "components/Member/MyPage/MyDogInfo";
 import { CardContainer, ContentContainer } from "components/Member/MyPage/styles";
 import { useGetMemberInfo } from "hooks/api/member/member";
+import { useNavigate } from "react-router-dom";
 
 const MemberMyPage = () => {
+  const navigate = useNavigate();
   const { data } = useGetMemberInfo();
 
   return (
     <>
       <LayoutContainer type="main">
         <PageContainer pt="1" imageUrl={data.memberProfileUri ?? placeholderImg}>
-          <Header type="setting" text="마이페이지" position="absolute" transparent />
+          <Header
+            type="setting"
+            text="마이페이지"
+            position="absolute"
+            handleClick={() => navigate(routes.member.mypage.setting.root)}
+            transparent
+          />
           <ContentContainer>
             <MemberProfile data={data} />
             <CardContainer>

--- a/src/pages/MemberPage/MemberMyPage.tsx
+++ b/src/pages/MemberPage/MemberMyPage.tsx
@@ -18,7 +18,7 @@ const MemberMyPage = () => {
   return (
     <>
       <LayoutContainer type="main">
-        <PageContainer pt="1" imageUrl={data.memberProfileUri ?? placeholderImg}>
+        <PageContainer pt="2" imageUrl={data.memberProfileUri ?? placeholderImg}>
           <Header
             type="setting"
             text="마이페이지"

--- a/src/pages/MemberPage/MemberSettingPage.tsx
+++ b/src/pages/MemberPage/MemberSettingPage.tsx
@@ -34,7 +34,7 @@ const MemberSettingPage = () => {
               onClick={() => setStep(1)}
             >
               <Text typo="body2_16_R" color="gray_1">
-                알림 설정1
+                알림 설정
               </Text>
               <ArrowRightIcon colorScheme="gray_3" size={20} />
             </Box>

--- a/src/pages/MemberPage/MemberSettingPage.tsx
+++ b/src/pages/MemberPage/MemberSettingPage.tsx
@@ -1,0 +1,108 @@
+import ArrowRightIcon from "assets/svg/arrow-right-icon";
+import { Box, Flex, Layout, Text } from "components/common";
+import { Button } from "components/common/Button";
+import Header from "components/common/Header";
+import AlertSetting from "components/Member/MyPage/Setting/AlertSetting";
+import { AlertSettingProvider } from "components/Member/MyPage/Setting/AlertSetting/context/AlertSettingProvider";
+import DeleteAccount from "components/Member/MyPage/Setting/DeleteAccount";
+import PolicySetting from "components/Member/MyPage/Setting/PolicySetting";
+import useStep from "hooks/common/useStep";
+import { useTokenHandler } from "hooks/common/useTokenHandler";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const MemberSettingPage = () => {
+  const navigate = useNavigate();
+  const { currentStep, setStep } = useStep(3);
+  //FIXME: 업데이트 유무 리팩토링 필요!
+  const [isNeedUpdate, setIsNeedUpdate] = useState(false);
+  const { role } = useTokenHandler();
+
+  return (
+    <>
+      {currentStep === 0 && (
+        <>
+          <Header type="text" text="설정" />
+          <Layout type="detail" pt="0.3rem" paddingX="1rem">
+            <Box
+              display="flex"
+              height="56px"
+              justify="space-between"
+              align="center"
+              borderBottom={1}
+              borderColor="gray_5"
+              onClick={() => setStep(1)}
+            >
+              <Text typo="body2_16_R" color="gray_1">
+                알림 설정1
+              </Text>
+              <ArrowRightIcon colorScheme="gray_3" size={20} />
+            </Box>
+            <Box
+              display="flex"
+              height="56px"
+              justify="space-between"
+              align="center"
+              borderBottom={1}
+              borderColor="gray_5"
+              onClick={() => setStep(2)}
+            >
+              <Text typo="body2_16_R" color="gray_1">
+                정책
+              </Text>
+              <ArrowRightIcon colorScheme="gray_3" size={20} />
+            </Box>
+            <Box
+              display="flex"
+              direction="column"
+              height="92px"
+              justify="center"
+              borderBottom={1}
+              borderColor="gray_5"
+            >
+              <Flex justify="space-between">
+                <Text typo="body2_16_R" color="gray_1">
+                  버전정보 및 업데이트
+                </Text>
+                {isNeedUpdate && (
+                  <Button variant="pill" colorScheme="primary" typo="caption1_12_B" size="xs">
+                    업데이트 하기
+                  </Button>
+                )}
+              </Flex>
+              <Text typo="caption1_12_R" color={isNeedUpdate ? "primaryColor" : "gray_2"}>
+                {isNeedUpdate ? "업데이트가 필요합니다" : "가장 최신 버전입니다"}
+              </Text>
+              <Text typo="caption1_12_R" color="gray_2">
+                똑독 2.0
+              </Text>
+            </Box>
+            <Box
+              display="flex"
+              height="56px"
+              justify="space-between"
+              align="center"
+              borderBottom={1}
+              borderColor="gray_5"
+              onClick={() => setStep(3)}
+            >
+              <Text typo="body2_16_R" color="gray_1">
+                탈퇴하기
+              </Text>
+              <ArrowRightIcon colorScheme="gray_3" size={20} />
+            </Box>
+          </Layout>
+        </>
+      )}
+      {currentStep === 1 && (
+        <AlertSettingProvider>
+          <AlertSetting setStep={setStep} role={role} />
+        </AlertSettingProvider>
+      )}
+      {currentStep === 2 && <PolicySetting setStep={setStep} />}
+      {currentStep === 3 && <DeleteAccount setStep={setStep} role={role} />}
+    </>
+  );
+};
+
+export default MemberSettingPage;

--- a/src/pages/MyPage/UnregisterSuccessPage.tsx
+++ b/src/pages/MyPage/UnregisterSuccessPage.tsx
@@ -1,11 +1,25 @@
-import { Layout } from "components/common";
-import UnregisterSuccess from "components/Unregister/Success";
+import { routes } from "constants/path";
+
+import { Layout, Text } from "components/common";
+import { BottomButton } from "components/common/Button";
+import { useNavigate } from "react-router-dom";
 
 const UnregisterSuccessPage = () => {
+  const navigate = useNavigate();
+
   return (
-    <Layout bgColor="white" pt={76} px={16}>
-      <UnregisterSuccess />
-    </Layout>
+    <>
+      <Layout bgColor="white" px={16} pt={76}>
+        <Text as="h2" typo="title1_24_B" color="darkBlack">
+          <Text as="em" typo="inherit" color="primaryColor">
+            탈퇴
+          </Text>
+          가 완료되었습니다
+        </Text>
+        <Text color="gray_3">똑독 유치원에서 다시 만날 날을 기다릴게요</Text>
+      </Layout>
+      <BottomButton onClick={() => navigate(routes.login.root)}>로그인 화면으로 이동</BottomButton>
+    </>
   );
 };
 

--- a/src/pages/MyPage/UnregisterSuccessPage.tsx
+++ b/src/pages/MyPage/UnregisterSuccessPage.tsx
@@ -2,10 +2,17 @@ import { routes } from "constants/path";
 
 import { Layout, Text } from "components/common";
 import { BottomButton } from "components/common/Button";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 const UnregisterSuccessPage = () => {
   const navigate = useNavigate();
+
+  useEffect(() => {
+    setTimeout(() => {
+      navigate(routes.login.root);
+    }, 3000);
+  }, []);
 
   return (
     <>

--- a/src/pages/MyPage/UnregisterSuccessPage.tsx
+++ b/src/pages/MyPage/UnregisterSuccessPage.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from "react-router-dom";
 const UnregisterSuccessPage = () => {
   const navigate = useNavigate();
 
+  // 3초 이상 머물 경우 강제로 로그인 화면으로 이동
   useEffect(() => {
     setTimeout(() => {
       navigate(routes.login.root);

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -71,6 +71,7 @@ export { default as MemberDogInfoEditPage } from "./MemberPage/MemberDogInfoEdit
 export { default as MemberProfileEditPage } from "./MemberProfileEditPage/MemberProfileEditPage";
 export { default as MemberAddDogProfileEditPage } from "./MemberPage/MemberAddDogProfileEditPage";
 export { default as MemberEnrollmentPage } from "./MemberPage/MemberEnrollmentFunnel";
+export { default as MemberSettingPage } from "./MemberPage/MemberSettingPage";
 
 /* Common Page */
 export { default as NotFoundPage } from "./ErrorPage/NotFoundPage";

--- a/src/routes/MemberRoutes.tsx
+++ b/src/routes/MemberRoutes.tsx
@@ -121,6 +121,14 @@ const MemberRoutes = ({ queryClient }: { queryClient: QueryClient }): RouteObjec
               <Pages.MemberEnrollmentPage />
             </Suspense>
           )
+        },
+        {
+          path: routes.member.mypage.setting.root,
+          element: (
+            <Suspense>
+              <Pages.MemberSettingPage />
+            </Suspense>
+          )
         }
       ]
     }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

- 견주 마이페이지 QA관련 이슈를 해결합니다.
[견주 정보 수정 페이지 - 호칭 UI 변경](https://www.notion.so/1196c15f67fb80e49811df73fe74baa0)
[견주 정보 수정 페이지 - 수정 완료 플로우 변경](https://www.notion.so/1196c15f67fb80a9aa7ac81fcca715b5)
[강아지 한 마리일 때 화면 움직임 이슈](https://www.notion.so/1196c15f67fb80ef975edcf0b6efda91)
[header 안 보이는 이슈](https://www.notion.so/1196c15f67fb80398ee9fba8699d99b5)

- (추가 발견한 이슈) 강아지 삭제 조건문을 수정합니다.
- (추가 발견한 이슈) 설정 페이지 연결 합니다. (탈퇴, 알림 확인 필요)
- 기타 틀어진 UI를 수정합니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->


- [x] (견주 정보 수정 페이지) 프로필 등록 페이지 호칭 UI와 맞추기
- [x] (견주 정보 수정 페이지) 수정 완료 시 프로필 페이지로 이동 + toast 띄우기
- [x] 강아지 삭제 시 doglist 첫번째 dogId로 변경하기
- [x] 강아지 한 마리일 때의 카드 컴포넌트 넓이 수정
- [x] header 설정 버튼 클릭 시 설정 페이지로 이동 및 member 기능으로 맞추기 (임시)
   (admin 컴포넌트 코드 가져와 수정함 - 나중에 리팩토링 및 기능 확인 필요)
- [x] 기타 UI 틀어진 부분 수정



## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

- 설정 페이지는 admin 페이지를 가져와 member 기능에 맞춰 수정만 했습니다. (나중에 리팩토링 및 기능 확인해야합니다.)
   - @hyerani admin 설정 페이지 피그마에 나와있는 대로 아이콘 추가, 탈퇴 완료 시 3초 후 자동 이동, 체크박스 늘어짐 이슈 작업해 둬서 pull 받으시고 틀어진 곳 없는지 확인 부탁드립니다!
   [Design: admin 탈퇴 완료 페이지 member와 동일하게 늘어난 체크박스 및 뒤에 배경 추가](https://github.com/PetCampus-Inc/daeng_v1_front/pull/264/commits/ab6f7cc546e06518fb2b516c78acc9e602c2eff0)
- 탈퇴 기능이 없어 추가 요청한 상태 입니다. (탈퇴 기능 추가 되면 hotfix로 pr올리겠습니다. - 지금 브랜치는 잘못 작성함...^^)
- Header 컴포넌트 position 타입 추가했습니다.


@yeomgahui @seongnam95 @hyerani @im-na0

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
