### PR TITLE
Fix: [2차 QA] 강아지 상세 페이지 이슈

### DIFF
--- a/src/apis/member/enrollment.api.ts
+++ b/src/apis/member/enrollment.api.ts
@@ -112,13 +112,15 @@ export const handlePostMemberDogSchool = async (dogId: string): Promise<void> =>
 
 /**
  * @description 강아지 가입 신청서 보기 - 강아지의 가입신청서를 보여줍니다.
- * @param {number} dogId
+ * @param {number} enrollmentFormId
  */
-export const handleGetDogEnrollment = async (dogId: number): Promise<IDogEnrollmentInfo> => {
+export const handleGetDogEnrollment = async (
+  enrollmentFormId: number
+): Promise<IDogEnrollmentInfo> => {
   const url = `member/dog/enrollment`;
   const { data } = await authAxios.get(url, {
     params: {
-      dogId
+      enrollmentFormId
     }
   });
   return data.data;

--- a/src/components/Member/DogInfo/DogDetailInfoEdit/Buttons/SaveButton.tsx
+++ b/src/components/Member/DogInfo/DogDetailInfoEdit/Buttons/SaveButton.tsx
@@ -10,7 +10,11 @@ import { type MemberDogInfoReq } from "types/member/main.types";
 import { getKeyForLabel } from "utils/formatter";
 
 const SaveButton = ({ dogId }: { dogId: number }) => {
-  const { getValues, handleSubmit } = useFormContext();
+  const {
+    getValues,
+    handleSubmit,
+    formState: { isDirty, isValid }
+  } = useFormContext();
 
   const [shouldSubmit, setShouldSubmit] = useState(false);
   const { s3ProfileData, uploadFiles } = useUploadProfile();
@@ -76,7 +80,11 @@ const SaveButton = ({ dogId }: { dogId: number }) => {
   }, [s3ProfileData, shouldSubmit]);
 
   return (
-    <BottomButton onClick={handleSubmit(handleSubmitData)} position="relative">
+    <BottomButton
+      onClick={handleSubmit(handleSubmitData)}
+      disabled={!isDirty || !isValid}
+      position="relative"
+    >
       수정 완료
     </BottomButton>
   );

--- a/src/components/Member/DogInfo/Enrollment/EnrollmentDogDetail.tsx
+++ b/src/components/Member/DogInfo/Enrollment/EnrollmentDogDetail.tsx
@@ -12,13 +12,12 @@ import * as S from "components/Enrollment/styles";
 import { useGetMemberDogEnrollmentInfo } from "hooks/api/member/member";
 import useStep from "hooks/common/useStep";
 import { FormProvider, useForm } from "react-hook-form";
+import { useParams } from "react-router-dom";
 
-interface EnrollmentProps {
-  dogId?: number; // MEMO: 강아지 상세 정보에서 제공
-}
+const EnrollmentDogDetail = () => {
+  const { enrollmentFormId } = useParams();
 
-const EnrollmentDogDetail = ({ dogId }: EnrollmentProps) => {
-  const { data } = useGetMemberDogEnrollmentInfo(Number(dogId));
+  const { data } = useGetMemberDogEnrollmentInfo(Number(enrollmentFormId));
   const { schoolFormResponse, ...rest } = data;
 
   const methods = useForm({

--- a/src/components/Member/DogInfo/Main/Box/DogInfoBox.tsx
+++ b/src/components/Member/DogInfo/Main/Box/DogInfoBox.tsx
@@ -69,7 +69,11 @@ const DogInfoBox = ({ data, dogId }: DogInfoProps) => {
       </S.DogInfoBox>
 
       <S.GotoEnrollButton
-        onClick={() => navigate(routes.member.dogInfo.enrollment.dynamic(String(dogId)))}
+        onClick={() =>
+          navigate(
+            routes.member.dogInfo.enrollment.dynamic(String(dogId), String(data.enrollmentFormId))
+          )
+        }
       >
         <span>{data.dogName}의 가입신청서</span>
         <ArrowRightIcon />

--- a/src/components/Member/DogInfo/styles.ts
+++ b/src/components/Member/DogInfo/styles.ts
@@ -224,7 +224,33 @@ export const CarouselContainer = styled.div`
   overflow-x: auto;
 `;
 
-export const DragCarouselWrapper = styled.div``;
+export const DragCarouselWrapper = styled.div`
+  & > div {
+    overflow-x: auto;
+    touch-action: unset;
+    padding-bottom: 0.625rem;
+  }
+
+  /**스크롤 디자인 */
+  & > div::-webkit-scrollbar {
+    height: 0.375rem;
+  }
+
+  & > div::-webkit-scrollbar-thumb {
+    background-color: ${({ theme }) => theme.colors.gray_3};
+    border-radius: 8px;
+  }
+
+  & > div::-webkit-scrollbar-track {
+    background-color: ${({ theme }) => theme.colors.gray_4};
+    border-radius: 8px;
+  }
+
+  & > div::-webkit-scrollbar-button,
+  & > div::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+`;
 
 export const CarouselCard = styled.div`
   position: relative;

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -216,7 +216,8 @@ const member = {
     },
     /** 유치원 가입신청서 */
     enrollment: {
-      dynamic: (dogId?: Parameter) => `/dog-info/${dogId ?? ":dogId"}/enrollment/detail`
+      dynamic: (dogId?: Parameter, enrollmentFormId?: Parameter) =>
+        `/dog-info/${dogId ?? ":dogId"}/enrollment/${enrollmentFormId ?? ":enrollmentFormId"}/detail`
     }
   },
   /** 온보딩 후 초기 프로필 설정 */

--- a/src/hooks/api/member/member.ts
+++ b/src/hooks/api/member/member.ts
@@ -172,10 +172,10 @@ export const usePostMemberDogDelete = () => {
 };
 
 // 강아지 가입신청서 보기 (read only)
-export const useGetMemberDogEnrollmentInfo = (dogId: number) => {
+export const useGetMemberDogEnrollmentInfo = (enrollmentFormId: number) => {
   return useSuspenseQuery({
-    queryKey: QUERY_KEY.MEMBER_DOG_ENROLLMENT_INFO(dogId),
-    queryFn: () => handleGetDogEnrollment(dogId)
+    queryKey: QUERY_KEY.MEMBER_DOG_ENROLLMENT_INFO(enrollmentFormId),
+    queryFn: () => handleGetDogEnrollment(enrollmentFormId)
   });
 };
 

--- a/src/pages/MemberPage/MemberDogInfoEditPage.tsx
+++ b/src/pages/MemberPage/MemberDogInfoEditPage.tsx
@@ -46,7 +46,7 @@ const MemberDogInfoEditPage = () => {
           action={() => blocker.proceed()}
         />
       ) : null}
-      <Header type="text" text={`${data.dogName}의 가입정보 수정1`} />
+      <Header type="text" text={`${data.dogName}의 가입정보 수정`} />
       <Layout pt={44} bgColor="white">
         <FormProvider {...methods}>
           <DogDetailInfoEdit />

--- a/src/pages/MemberPage/MemberDogInfoEditPage.tsx
+++ b/src/pages/MemberPage/MemberDogInfoEditPage.tsx
@@ -7,6 +7,7 @@ import { useGetMemberDogDetailInfo } from "hooks/api/member/member";
 import { FormProvider, useForm } from "react-hook-form";
 import { useBlocker, useParams } from "react-router-dom";
 import { getPadString } from "utils/date";
+import { isEmpty } from "utils/is";
 
 const MemberDogInfoEditPage = () => {
   const { dogId } = useParams();
@@ -33,7 +34,8 @@ const MemberDogInfoEditPage = () => {
     }
   });
 
-  const blocker = useBlocker(() => methods.formState.isDirty);
+  const { dirtyFields, isSubmitSuccessful } = methods.formState;
+  const blocker = useBlocker(() => !isSubmitSuccessful && !isEmpty(dirtyFields));
 
   return (
     <>
@@ -44,7 +46,7 @@ const MemberDogInfoEditPage = () => {
           action={() => blocker.proceed()}
         />
       ) : null}
-      <Header type="text" text={`${data.dogName}의 가입정보 수정`} />
+      <Header type="text" text={`${data.dogName}의 가입정보 수정1`} />
       <Layout pt={44} bgColor="white">
         <FormProvider {...methods}>
           <DogDetailInfoEdit />

--- a/src/pages/MemberPage/MemberEnrollmentDogInfoPage.tsx
+++ b/src/pages/MemberPage/MemberEnrollmentDogInfoPage.tsx
@@ -1,10 +1,7 @@
 import EnrollmentDogDetail from "components/Member/DogInfo/Enrollment/EnrollmentDogDetail";
-import { useParams } from "react-router-dom";
 
 const MemberEnrollmentDogInfoPage = () => {
-  const { dogId } = useParams();
-
-  return <EnrollmentDogDetail dogId={Number(dogId)} />;
+  return <EnrollmentDogDetail />;
 };
 
 export default MemberEnrollmentDogInfoPage;

--- a/src/types/member/main.types.ts
+++ b/src/types/member/main.types.ts
@@ -103,6 +103,7 @@ export interface VaccinationUri {
 }
 export interface MemberDogInfoData {
   dogId: number;
+  enrollmentFormId: number;
   dogName: string;
   dogGender: DogGenderType | string;
   dogSize: DogSizeType | string;


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

- 강아지 상세 정보 페이지 QA 이슈를 해결합니다.
[강아지 정보 수정 들어갔다가 뒤로 나올때 팝업 안 뜨는 이슈](https://www.notion.so/1196c15f67fb80c7a880c625cdb60078)
[강아지 상세 정보 수정 버튼 활성화](https://www.notion.so/1196c15f67fb80ddaee0fdc56aa98c7d) (임시 수정 - 답변 대기 중)
[강아지 가입신청서 404 에러](https://www.notion.so/1196c15f67fb80d19cb0d224cc54ccbb)
[강아지 예방 접종파일 3개 이상일 경우 하단 스크롤 안 보이는 이슈](https://www.notion.so/1196c15f67fb800db8ebd848c768b295)

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

- [x] 강아지 정보 수정 후 뒤로가기 버튼 클릭 시 팝업창 나오도록 useBlocker 조건문 수정
- [x] 강아지 정보 수정 해야 버튼 활성화 되도록 수정 (임시 수정 - 답변 후 재수정이 필요할 수 있음)
- [x] 강아지 가입신청서 dogId -> enrollmentFormId로 params 수정
- [x] 강아지 예방 접종파일 3개 이상일 경우 하단 스크롤 보이도록 UI 작업

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->
- 강아지 상세 정보 수정 버튼 활성화 부분은 주말에 답변 받기로 해서 이후 수정 될 수 있습니다.
   -  우선 마이페이지 수정 버튼 하고 동일하게 맞췄습니다. (이부분 전달 함)

@yeomgahui @seongnam95 @hyerani @im-na0 

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
