### PR TITLE
Fix: 상세 페이지 강아지 프로필 이미지 표시 로직 수정

### DIFF
--- a/src/assets/svg/arrow-left-icon.tsx
+++ b/src/assets/svg/arrow-left-icon.tsx
@@ -5,16 +5,16 @@ import type { IconProps } from "./types";
 const ArrowLeftIcon = ({ size = 24, color = "darkBlack" }: IconProps) => {
   return (
     <svg
-      xmlns="http://www.w3.org/2000/svg"
       width={size}
       height={size}
-      viewBox="0 0 24 24"
+      viewBox="0 0 30 30"
       fill={themeConfig.colors[color]}
+      xmlns="http://www.w3.org/2000/svg"
     >
       <path
         fillRule="evenodd"
-        d="M15.778 5.707a1 1 0 0 0-1.414 0l-5.651 5.651a1 1 0 0 0-.006 1.42l5.657 5.657a1 1 0 0 0 1.414-1.414l-4.95-4.95 4.95-4.95a1 1 0 0 0 0-1.414Z"
         clipRule="evenodd"
+        d="M18.2051 7.36612C17.717 6.87796 16.9255 6.87796 16.4374 7.36612L9.37329 14.4302C9.37089 14.4326 9.3685 14.4349 9.36612 14.4373C8.87796 14.9255 8.87796 15.7169 9.36612 16.2051L16.4372 23.2761C16.9253 23.7643 17.7168 23.7643 18.205 23.2761C18.6931 22.788 18.6931 21.9965 18.205 21.5084L12.0178 15.3212L18.2051 9.13388C18.6933 8.64573 18.6933 7.85427 18.2051 7.36612Z"
       />
     </svg>
   );

--- a/src/assets/svg/arrow-right-icon.tsx
+++ b/src/assets/svg/arrow-right-icon.tsx
@@ -1,40 +1,20 @@
+import { themeConfig } from "styles/themeConfig";
+
 import type { IconProps } from "./types";
 
-interface Props extends Omit<IconProps, "color"> {
-  colorScheme?:
-    | "gray_1"
-    | "gray_2"
-    | "gray_3"
-    | "gray_4"
-    | "gray_5"
-    | "black"
-    | "darkBlack"
-    | "none";
-}
-
-const ArrowRightIcon = ({ size = 24, colorScheme = "none" }: Props) => {
-  const colorMap = new Map<string, string>([
-    ["gray_1", "#525252"],
-    ["gray_2", "#858585"],
-    ["gray_3", "#B5B5B5"],
-    ["gray_4", "#E9E9E9"],
-    ["gray_5", "#F6F6F6"],
-    ["black", "#000000"],
-    ["darkBlack", "#292929"],
-    ["none", "currentColor"]
-  ]);
+const ArrowRightIcon = ({ size = 24, color = "darkBlack" }: IconProps) => {
   return (
     <svg
       width={size}
       height={size}
-      viewBox="0 0 24 24"
-      fill={colorMap.get(colorScheme)}
+      viewBox="0 0 30 30"
+      fill={themeConfig.colors[color]}
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
         fillRule="evenodd"
         clipRule="evenodd"
-        d="M8.5353 5.39299C8.92583 5.00247 9.55899 5.00247 9.94952 5.39299L15.6008 11.0443C15.6027 11.0461 15.6046 11.048 15.6065 11.05C15.997 11.4405 15.997 12.0736 15.6065 12.4642L9.94967 18.121C9.55914 18.5115 8.92598 18.5115 8.53545 18.121C8.14493 17.7305 8.14493 17.0973 8.53545 16.7068L13.4852 11.7571L8.5353 6.8072C8.14478 6.41668 8.14478 5.78352 8.5353 5.39299Z"
+        d="M11.3661 23.2761C11.8543 23.7643 12.6458 23.7642 13.1339 23.2761L20.198 16.212C20.2004 16.2097 20.2028 16.2073 20.2052 16.2049C20.6933 15.7167 20.6933 14.9253 20.2052 14.4371L13.1341 7.36606C12.646 6.87791 11.8545 6.87791 11.3663 7.36606C10.8782 7.85422 10.8782 8.64567 11.3663 9.13383L17.5535 15.321L11.3662 21.5083C10.878 21.9965 10.878 22.7879 11.3661 23.2761Z"
       />
     </svg>
   );

--- a/src/components/Admin/AttendCare/AttendCareGallery/SendFileButton.tsx
+++ b/src/components/Admin/AttendCare/AttendCareGallery/SendFileButton.tsx
@@ -1,7 +1,6 @@
 import { routes } from "constants/path";
 
 import { BottomButton } from "components/common/Button";
-import { useState } from "react";
 import { FieldValues, useFormContext } from "react-hook-form";
 import { useNavigate, useParams } from "react-router-dom";
 import { useSetRecoilState } from "recoil";
@@ -21,7 +20,6 @@ const SendFileButton = ({ type }: Props) => {
   const { dogId } = useParams<{ dogId: string }>();
   const { handleSubmit, getValues } = useFormContext();
   const setGalleryImg = useSetRecoilState(galleryImgState);
-  const [totalFiles, setTotalFiles] = useState(0);
   const { uploadFiles } = useUploadAndCreateAlbum();
   const navigate = useNavigate();
 
@@ -46,8 +44,6 @@ const SendFileButton = ({ type }: Props) => {
 
       if (!dogId) throw new Error("dogId is required");
 
-      setTotalFiles(data.files.length);
-
       const params = {
         files: data.files,
         accept: ["image/*", "video/*"],
@@ -58,7 +54,10 @@ const SendFileButton = ({ type }: Props) => {
 
       await uploadFiles(params, {
         onSuccess: () => {
-          navigate(routes.admin.care.notice.dynamic(dogId), { replace: true });
+          navigate(routes.admin.care.notice.dynamic(dogId), {
+            state: { tab: "album" },
+            replace: true
+          });
         }
       });
     }

--- a/src/components/Admin/AttendCare/AttendCareGallery/SubmitButton.tsx
+++ b/src/components/Admin/AttendCare/AttendCareGallery/SubmitButton.tsx
@@ -1,7 +1,7 @@
 import { routes } from "constants/path";
 
 import { BottomButton } from "components/common/Button";
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import { galleryImgState } from "store/images";
@@ -13,7 +13,6 @@ import useUploadAndCreateAlbum from "../hooks/useUploadAndCreateAlbum";
 const SubmitButton = () => {
   const selectIdsContext = useContext(SelectedIdsContext);
   const selectedDogIds = Array.from(selectIdsContext?.selectedIds ?? []);
-  const [totalFiles, setTotalFiles] = useState(0);
   const galleryData = useRecoilValue(galleryImgState);
   const { uploadFiles } = useUploadAndCreateAlbum();
   const navigate = useNavigate();
@@ -23,7 +22,6 @@ const SubmitButton = () => {
       showToast("업로드할 파일이 없습니다.", "ownerNav");
       return;
     }
-    setTotalFiles(galleryData.files.length);
 
     const params = {
       files: galleryData.files,

--- a/src/components/Admin/AttendCareNotice/DailyAgenda/CreateAgenda.tsx
+++ b/src/components/Admin/AttendCareNotice/DailyAgenda/CreateAgenda.tsx
@@ -31,10 +31,10 @@ export function CreateAgenda({ savedData }: { savedData: PastAgenda }) {
 
   const defaultValues = useMemo(
     () => ({
-      agendaNote: savedData.agendaNote,
-      snack: savedData.snack,
-      poopMemo: savedData.poopMemo,
-      poop: savedData.poop
+      agendaNote: savedData.agendaNote ?? "",
+      snack: savedData.snack ?? "",
+      poopMemo: savedData.poopMemo ?? "",
+      poop: savedData.poop ?? ""
     }),
     [savedData]
   );

--- a/src/components/Admin/AttendCareNotice/PhotoAlbum/ImageGrid.tsx
+++ b/src/components/Admin/AttendCareNotice/PhotoAlbum/ImageGrid.tsx
@@ -1,0 +1,51 @@
+import { Image } from "components/common/Image";
+import React from "react";
+
+import * as Styled from "./styles";
+
+import type { ImageList } from "types/member/main.types";
+
+interface ImageGridProps {
+  items: ImageList[];
+  onImageClick: (images: ImageList[], index: number) => void;
+}
+
+/** 단일 이미지 */
+const ImageItem = ({
+  item,
+  onClick,
+  children
+}: {
+  item: ImageList;
+  onClick: () => void;
+  children?: React.ReactNode;
+}) => (
+  <Styled.ImageWrapper onClick={onClick}>
+    <Image src={item.imageUri} ratio="1/1" />
+    {children}
+  </Styled.ImageWrapper>
+);
+
+/** 이미지 그리드 */
+export function ImageGrid({ items, onImageClick }: ImageGridProps) {
+  const remainingCount = items.length > 4 ? items.length - 3 : 0;
+
+  return (
+    <Styled.ImageList>
+      {items.slice(0, 4).map((item, index) =>
+        index === 3 && remainingCount > 0 ? (
+          <ImageItem key={item.imageId} item={item} onClick={() => onImageClick(items, index)}>
+            {/* 남은 사진 갯수 표시 */}
+            <Styled.Dimmed>
+              <Styled.CountWrapper>
+                <Styled.Count>+{remainingCount}</Styled.Count>
+              </Styled.CountWrapper>
+            </Styled.Dimmed>
+          </ImageItem>
+        ) : (
+          <ImageItem key={item.imageId} item={item} onClick={() => onImageClick(items, index)} />
+        )
+      )}
+    </Styled.ImageList>
+  );
+}

--- a/src/components/Admin/AttendCareNotice/PhotoAlbum/PhotoAlbum.tsx
+++ b/src/components/Admin/AttendCareNotice/PhotoAlbum/PhotoAlbum.tsx
@@ -1,21 +1,22 @@
-import { MediaViewModal } from "components/Admin/DogGallery/SinglePicture/MediaViewModal";
 import { CommentCarouselLightBoxPopup } from "components/Album/LightBox/CommentCarouselLightBoxPopup";
 import { Flex, Text } from "components/common";
-import { Image } from "components/common/Image";
 import { format } from "date-fns";
 import { useGetMainAlbum } from "hooks/api/member/member";
 import { useOverlay } from "hooks/common/useOverlay";
 import { getRelativeTime } from "utils/date";
 
-import * as S from "./styles";
+import { ImageGrid } from "./ImageGrid";
 
 import type { ImageList } from "types/member/main.types";
 
-// FIXME: 1. 사진 가져오는 api 수정 2. ui 변경
 export function PhotoAlbum({ dogId }: { dogId: number }) {
-  const { data } = useGetMainAlbum({ dogId, date: format(new Date(), "yyyy-MM-dd") });
+  const { data } = useGetMainAlbum({
+    dogId,
+    date: format(new Date(), "yyyy-MM-dd")
+  });
   const overlay = useOverlay();
 
+  /** 사진 클릭 핸들러 */
   const handleImageClick = (images: ImageList[], currentIndex: number) => {
     overlay.open(({ isOpen, close }) => (
       <CommentCarouselLightBoxPopup
@@ -27,30 +28,24 @@ export function PhotoAlbum({ dogId }: { dogId: number }) {
     ));
   };
 
-  // TODO: 사진 없는 경우 디자인 수정
+  // FIXME: Empty 화면 디자인 수정 필요!!
+  if (!data || data.length === 0) {
+    return <Text>전송된 사진이 없습니다</Text>;
+  }
+
   return (
     <Flex direction="column" gap={28}>
-      {!data
-        ? "사진이 없습니다"
-        : data.map((arr: ImageList[], idx: number) => (
-            <Flex key={`${arr[0].imageId}-${idx}`} direction="column" gap={8}>
-              <Text color="gray_2" typo="body2_16_R">
-                {getRelativeTime(arr[0].createdTime)}
-              </Text>
+      {data.map((items: ImageList[]) => (
+        <Flex key={items[0].imageId} direction="column" gap={8}>
+          {/* 날짜 */}
+          <Text color="gray_2" typo="body2_16_R">
+            {getRelativeTime(items[0].createdTime)}
+          </Text>
 
-              <S.ImageList>
-                {arr.map((item: ImageList, index: number) => (
-                  <S.StyledImage key={`${item.imageId}-${index}`}>
-                    <Image
-                      src={item.imageUri}
-                      ratio="1/1"
-                      onClick={() => handleImageClick(arr, index)}
-                    />
-                  </S.StyledImage>
-                ))}
-              </S.ImageList>
-            </Flex>
-          ))}
+          {/* 사진 그리드 */}
+          <ImageGrid items={items} onImageClick={handleImageClick} />
+        </Flex>
+      ))}
     </Flex>
   );
 }

--- a/src/components/Admin/AttendCareNotice/PhotoAlbum/styles.ts
+++ b/src/components/Admin/AttendCareNotice/PhotoAlbum/styles.ts
@@ -1,18 +1,44 @@
 import styled from "styled-components";
-
 export const ImageList = styled.div`
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
   gap: 8px;
   overflow-x: auto;
   scrollbar-width: none;
-  -ms-overflow-style: none;
-  &::-webkit-scrollbar {
-    display: none;
-  }
 `;
 
-export const StyledImage = styled.div`
+export const ImageWrapper = styled.div`
+  position: relative;
   border-radius: 0.5rem;
-  max-width: 25%;
   overflow: hidden;
+  aspect-ratio: 1 / 1;
+`;
+
+export const Dimmed = styled.div`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 9;
+`;
+
+export const CountWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 100%;
+`;
+
+export const Count = styled.p`
+  ${({ theme }) => theme.typo.label2_14_R};
+  color: ${({ theme }) => theme.colors.white};
+
+  padding: 4px 8px;
+  background-color: rgba(0, 0, 0, 0.55);
+  border-radius: 9999px;
 `;

--- a/src/components/Admin/MyPage/MyPageCard/InfoCard.tsx
+++ b/src/components/Admin/MyPage/MyPageCard/InfoCard.tsx
@@ -29,7 +29,7 @@ const CardTitle = ({ handleClick, text }: { handleClick: () => void; text: strin
       <MoreButton
         p={0}
         onClick={handleClick}
-        rightAddon={<ArrowRightIcon size={20} colorScheme="gray_3" />}
+        rightAddon={<ArrowRightIcon size={20} color="gray_3" />}
       >
         {text}
       </MoreButton>

--- a/src/components/Admin/MyPage/PrincipalProfile/index.tsx
+++ b/src/components/Admin/MyPage/PrincipalProfile/index.tsx
@@ -29,7 +29,7 @@ const PrincipalProfile = ({ data, profileUri, onEdit }: PrincipalInfoProps) => {
             <S.PrimaryColorButton onClick={onEdit}>프로필 수정</S.PrimaryColorButton>
             <Flex justify="center" align="center" onClick={onEdit}>
               <S.Text className="name">{adminName} 원장님</S.Text>
-              <ArrowRightIcon size={24} colorScheme="darkBlack" />
+              <ArrowRightIcon size={24} color="darkBlack" />
             </Flex>
             <S.Text className="number">{phoneNumber}</S.Text>
             <S.Text className="id">{data.id}</S.Text>

--- a/src/components/Admin/MyPage/TeacherProfile/index.tsx
+++ b/src/components/Admin/MyPage/TeacherProfile/index.tsx
@@ -27,7 +27,7 @@ const TeacherProfile = ({ data, profileUri, onEdit }: TeacherInfoProps) => {
             <S.PrimaryColorButton onClick={onEdit}>프로필 수정</S.PrimaryColorButton>
             <Flex justify="center" align="center" onClick={onEdit}>
               <S.Text className="name">{adminName} 선생님</S.Text>
-              <ArrowRightIcon size={24} colorScheme="darkBlack" />
+              <ArrowRightIcon size={24} color="darkBlack" />
             </Flex>
             <S.Text className="number">{phoneNumber}</S.Text>
             <S.Text className="id">{data.id}</S.Text>

--- a/src/components/Album/LightBox/CommentCarouselLightBox.tsx
+++ b/src/components/Album/LightBox/CommentCarouselLightBox.tsx
@@ -43,8 +43,6 @@ export const CommentCarouselLightBox = ({
   const [totalFiles, setTotalFiles] = useState<number>(0);
   const { saveMedia, progress, isLoading, currentIndex: downloaded } = useSaveMedia();
 
-  const isPrevDisabled = currentIndex === 0;
-  const isNextDisabled = currentIndex === images.length - 1;
   const currentImage = images[currentIndex];
   const isVideo = currentImage.imageUri.endsWith("mp4");
 
@@ -57,8 +55,8 @@ export const CommentCarouselLightBox = ({
     beforeChange: (_: never, newIndex: number) => {
       setCurrentIndex(newIndex);
     },
-    nextArrow: <Arrows position="next" isDisabled={isNextDisabled} />,
-    prevArrow: <Arrows position="prev" isDisabled={isPrevDisabled} />
+    nextArrow: <Arrows position="next" />,
+    prevArrow: <Arrows position="prev" />
   };
 
   return (

--- a/src/components/Album/LightBox/SaveModeLightBox.tsx
+++ b/src/components/Album/LightBox/SaveModeLightBox.tsx
@@ -30,9 +30,6 @@ export const SaveModeLightBox = ({ images, onClose, currentSlide }: SaveModeLigh
   const [currentIndex, setCurrentIndex] = useState<number>(currentSlide);
   const [selectedImages, setSelectedImages] = useRecoilState(selectedImagesState);
 
-  const isPrevDisabled = currentIndex === 0;
-  const isNextDisabled = currentIndex === images.length - 1;
-
   const settings = {
     initialSlide: currentSlide,
     infinite: false,
@@ -42,8 +39,8 @@ export const SaveModeLightBox = ({ images, onClose, currentSlide }: SaveModeLigh
     beforeChange: (_: never, newIndex: number) => {
       setCurrentIndex(newIndex);
     },
-    nextArrow: <Arrows position="next" isDisabled={isNextDisabled} />,
-    prevArrow: <Arrows position="prev" isDisabled={isPrevDisabled} />
+    nextArrow: <Arrows position="next" />,
+    prevArrow: <Arrows position="prev" />
   };
 
   const handleToggleImg = (imageId: number, imageUri: string) => {

--- a/src/components/Home/Dashboard/DogCard.tsx
+++ b/src/components/Home/Dashboard/DogCard.tsx
@@ -91,7 +91,7 @@ const DogCard = ({ data }: DogCardProps) => {
               공지
             </Text>
           </Flex>
-          <ArrowRightIcon size={24} colorScheme="gray_2" />
+          <ArrowRightIcon size={24} color="gray_2" />
         </Flex>
       </BoxContainer>
     </>

--- a/src/components/Home/Dashboard/DogNote.tsx
+++ b/src/components/Home/Dashboard/DogNote.tsx
@@ -76,7 +76,7 @@ const DogNote = ({ data }: DogNoteProps) => {
               자세히 보기
             </Text>
           </Flex>
-          <ArrowRightIcon size={24} colorScheme="gray_1" />
+          <ArrowRightIcon size={24} color="gray_1" />
         </Flex>
         <CardContainer>
           <FootButton type="button" className={attendanceClass}>

--- a/src/components/Member/DogInfo/Main/CarouselModal/index.tsx
+++ b/src/components/Member/DogInfo/Main/CarouselModal/index.tsx
@@ -31,8 +31,8 @@ export const CarouselModal = ({
     slidesToShow: 1,
     slidesToScroll: 1,
     arrows: true,
-    nextArrow: <Arrows position="next" isDisabled={false} />,
-    prevArrow: <Arrows position="prev" isDisabled={false} />
+    nextArrow: <Arrows position="next" />,
+    prevArrow: <Arrows position="prev" />
   };
 
   return (

--- a/src/components/common/Button/Templates/MoreButton.tsx
+++ b/src/components/common/Button/Templates/MoreButton.tsx
@@ -29,7 +29,7 @@ export const MoreButton = ({
       paddingBlock={0}
       paddingInline={0}
       gap={0}
-      rightAddon={<ArrowRightIcon colorScheme={iconColorScheme} size={iconSize} />}
+      rightAddon={<ArrowRightIcon color={iconColorScheme} size={iconSize} />}
       {...props}
     >
       <a>{children}</a>

--- a/src/components/common/Calendar/MonthCalendar.tsx
+++ b/src/components/common/Calendar/MonthCalendar.tsx
@@ -66,22 +66,22 @@ export function MonthCalendar({ minDate, tileDate, variant = "member" }: MonthCa
         prevLabel={
           variant === "admin" ? (
             <Styled.NavigationButton bgColor="white">
-              <ArrowLeftIcon size={24} color="darkBlack" />
+              <ArrowLeftIcon size={24} color="current" />
             </Styled.NavigationButton>
           ) : (
             <Styled.NavigationButton bgColor="yellow_3" color="primaryColor">
-              <ArrowLeftIcon size={24} />
+              <ArrowLeftIcon size={24} color="current" />
             </Styled.NavigationButton>
           )
         }
         nextLabel={
           variant === "admin" ? (
             <Styled.NavigationButton bgColor="white">
-              <ArrowRightIcon size={24} />
+              <ArrowRightIcon size={24} color="current" />
             </Styled.NavigationButton>
           ) : (
             <Styled.NavigationButton bgColor="yellow_3" color="primaryColor">
-              <ArrowRightIcon size={24} />
+              <ArrowRightIcon size={24} color="current" />
             </Styled.NavigationButton>
           )
         }

--- a/src/components/common/Calendar/month-picker.tsx
+++ b/src/components/common/Calendar/month-picker.tsx
@@ -99,8 +99,8 @@ export const MonthPicker = ({
               formatYear={(locale, value) => format(value, "yyyy")}
               minDate={minDate}
               maxDate={new Date()}
-              prevLabel={<ArrowLeftIcon w={20} />}
-              nextLabel={<ArrowRightIcon w={20} />}
+              prevLabel={<ArrowLeftIcon size={20} />}
+              nextLabel={<ArrowRightIcon size={20} />}
               prev2Label={null}
               next2Label={null}
             />

--- a/src/components/common/Calendar/weekly-calendar.tsx
+++ b/src/components/common/Calendar/weekly-calendar.tsx
@@ -103,7 +103,7 @@ export const WeeklyCalendar = (props: WeeklyCalendarProps) => {
             {format(activeStartDate, "yyyy. MM", { locale: ko })}
           </Text>
           <NavigationButton bgColor="yellow_3" color="primaryColor" ml={12}>
-            <ArrowDownIcon size={24} />
+            <ArrowDownIcon size={24} color="current" />
           </NavigationButton>
         </StyledWeeklyTitle>
         {renderTodayButton && renderTodayButton}

--- a/src/components/common/Dropdown/DropdownTrigger.tsx
+++ b/src/components/common/Dropdown/DropdownTrigger.tsx
@@ -1,14 +1,4 @@
-import {
-  type ButtonHTMLAttributes,
-  type RefObject,
-  forwardRef,
-  useContext,
-  useRef,
-  Children,
-  cloneElement,
-  isValidElement,
-  ReactElement
-} from "react";
+import { type ButtonHTMLAttributes, type RefObject, forwardRef, useContext, useRef } from "react";
 
 import { DropdownContext } from "./DropdownContext";
 
@@ -18,7 +8,6 @@ type DropdownTriggerProps = ButtonHTMLAttributes<HTMLButtonElement>;
  * DropdownTrigger
  * 자식 엘리먼트에 자동으로 isOpen 상태를 주입합니다.
  * @param props
- * @param props.children ReactNode. 유효한 React 엘리먼트인 경우, isOpen prop이 자동으로 주입됩니다.
  * @param props.onClick 클릭 이벤트 핸들러. Dropdown의 toggle 함수와 함께 실행됩니다.
  * @param ref 전달된 ref 객체. 없으면 내부적으로 생성된 ref가 사용됩니다.
  */
@@ -53,13 +42,7 @@ const DropdownTrigger = forwardRef<HTMLButtonElement, DropdownTriggerProps>(
         aria-label="펼치기"
         role="button"
       >
-        {Children.map(children, (child) => {
-          return isValidElement(child)
-            ? cloneElement(child as ReactElement, {
-                isOpen: dropdownContext?.isOpen ?? false
-              })
-            : child;
-        })}
+        {children}
       </span>
     );
   }

--- a/src/components/common/LightBox/Arrows.tsx
+++ b/src/components/common/LightBox/Arrows.tsx
@@ -24,8 +24,8 @@ export function Arrows({ position, isDisabled, ...props }: ArrowsProps) {
           exit="hidden"
           variants={arrowVariants}
         >
-          {position === "next" && <ArrowRightIcon size={30} />}
-          {position === "prev" && <ArrowLeftIcon size={30} />}
+          {position === "next" && <ArrowRightIcon size={30} color="gray_4" />}
+          {position === "prev" && <ArrowLeftIcon size={30} color="gray_4" />}
           <SrOnly>{position} slide</SrOnly>
         </ArrowButton>
       )}

--- a/src/components/common/LightBox/Arrows.tsx
+++ b/src/components/common/LightBox/Arrows.tsx
@@ -1,21 +1,32 @@
 import ArrowLeftIcon from "assets/svg/arrow-left-icon";
 import ArrowRightIcon from "assets/svg/arrow-right-icon";
 import { AnimatePresence, motion } from "framer-motion";
+import { useMemo } from "react";
 import styled from "styled-components";
 import { arrowVariants } from "styles/foundations/animation";
 
-interface ArrowsProps {
+import type { CustomArrowProps } from "react-slick";
+
+interface ArrowsProps extends CustomArrowProps {
   position: "next" | "prev";
-  isDisabled: boolean;
 }
 
-export function Arrows({ position, isDisabled, ...props }: ArrowsProps) {
+export function Arrows({ position, currentSlide, slideCount, ...props }: ArrowsProps) {
+  const isDisabled = useMemo(() => {
+    switch (position) {
+      case "next":
+        return slideCount && currentSlide === slideCount - 1;
+      case "prev":
+        return currentSlide === 0;
+    }
+  }, [position, currentSlide, slideCount]);
+
   return (
     <AnimatePresence mode="wait">
       {!isDisabled && (
         <ArrowButton
           {...props}
-          className=""
+          className={""}
           type="button"
           as={motion.button}
           position={position}
@@ -23,6 +34,7 @@ export function Arrows({ position, isDisabled, ...props }: ArrowsProps) {
           animate="visible"
           exit="hidden"
           variants={arrowVariants}
+          aria-label={`${position === "next" ? "다음" : "이전"} 슬라이드`}
         >
           {position === "next" && <ArrowRightIcon size={30} color="gray_4" />}
           {position === "prev" && <ArrowLeftIcon size={30} color="gray_4" />}

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -25,7 +25,7 @@ const ADMIN_QUERY_KEY = {
 };
 
 const MEMBER_QUERY_KEY = {
-  MEMBER_MAIN_ALBUM: (dogId: number, date?: string) => ["mainAlbum", dogId, date], // 멤버 메인 앨범
+  MEMBER_MAIN_ALBUM: (dogId?: number, date?: string) => ["mainAlbum", dogId, date], // 멤버 메인 앨범
   MEMBER_DOG_DETAIL_INFO: (dogId: number) => ["memberDogDetail", dogId], // 강아지 상세 정보
   MEMBER_DOG_ENROLLMENT_INFO: (dogId: number) => ["memberDogEnrollmentinfo", dogId], // 강아지 가입 신청서 (read only)
   SCHOOL_INFO_LIST: ["shcollInfoList"], // 마이페이지 견주의 강아지 유치원 정보

--- a/src/pages/AdminAttendCarePage/AttendCareNoticePage/AgendaView.tsx
+++ b/src/pages/AdminAttendCarePage/AttendCareNoticePage/AgendaView.tsx
@@ -1,11 +1,9 @@
 import { CreateAgenda, DailyAgenda } from "components/Admin/AttendCareNotice/DailyAgenda";
 import { Box } from "components/common";
 import { useGetAgendaSaved } from "hooks/api/admin/care";
-import { useParams } from "react-router-dom";
 
-export function AgendaView() {
-  const { dogId } = useParams();
-  const { data: savedData } = useGetAgendaSaved(Number(dogId));
+export function AgendaView({ dogId }: { dogId: number }) {
+  const { data: savedData } = useGetAgendaSaved(dogId);
 
   return (
     <Box pt={28}>

--- a/src/pages/AdminAttendCarePage/AttendCareNoticePage/AttendCareNoticePage.tsx
+++ b/src/pages/AdminAttendCarePage/AttendCareNoticePage/AttendCareNoticePage.tsx
@@ -2,24 +2,25 @@ import DogInfoBox from "components/Admin/AttendCareNotice/DogInfoBox";
 import { Box, Layout } from "components/common";
 import Header from "components/common/Header";
 import { Tabs } from "components/common/Tabs";
+import { useGetCachedCareDog } from "hooks/api/admin/care";
 import { Suspense } from "react";
-import { useLocation } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import styled from "styled-components";
 
 import { AgendaView } from "./AgendaView";
 import { PhotoAlbumView } from "./PhotoAlbumView";
 
 const AttendCareNoticePage = () => {
-  const { state } = useLocation();
-  const { dogName, profileUri } = state;
+  const { dogId } = useParams();
+  const { data } = useGetCachedCareDog(Number(dogId));
 
   return (
     <Layout type="page">
       <Tabs.Root variant="toggle" defaultValue="agenda">
         <StickyHeader>
           <Gradient>
-            <Header type="text" text={`${dogName} 상세페이지`} transparent />
-            <DogInfoBox dogName={dogName} profileUri={profileUri} />
+            <Header type="text" text={`${data.dogName} 상세페이지`} transparent />
+            <DogInfoBox dogName={data.dogName} profileUri={data.profileUri} />
           </Gradient>
           <Box bgColor="white" px={16}>
             <Tabs.List>
@@ -32,12 +33,12 @@ const AttendCareNoticePage = () => {
         <Box bgColor="white" px={16} pb={16}>
           <Tabs.Content value="agenda">
             <Suspense fallback={<AgendaView.Skeleton />}>
-              <AgendaView />
+              <AgendaView dogId={Number(dogId)} />
             </Suspense>
           </Tabs.Content>
           <Tabs.Content value="album">
             <Suspense>
-              <PhotoAlbumView />
+              <PhotoAlbumView dogId={Number(dogId)} />
             </Suspense>
           </Tabs.Content>
         </Box>

--- a/src/pages/AdminAttendCarePage/AttendCareNoticePage/AttendCareNoticePage.tsx
+++ b/src/pages/AdminAttendCarePage/AttendCareNoticePage/AttendCareNoticePage.tsx
@@ -4,7 +4,7 @@ import Header from "components/common/Header";
 import { Tabs } from "components/common/Tabs";
 import { useGetCachedCareDog } from "hooks/api/admin/care";
 import { Suspense } from "react";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import styled from "styled-components";
 
 import { AgendaView } from "./AgendaView";
@@ -14,9 +14,11 @@ const AttendCareNoticePage = () => {
   const { dogId } = useParams();
   const { data } = useGetCachedCareDog(Number(dogId));
 
+  const { state } = useLocation();
+
   return (
     <Layout type="page">
-      <Tabs.Root variant="toggle" defaultValue="agenda">
+      <Tabs.Root variant="toggle" defaultValue={state?.tab === "album" ? "album" : "agenda"}>
         <StickyHeader>
           <Gradient>
             <Header type="text" text={`${data.dogName} 상세페이지`} transparent />

--- a/src/pages/AdminAttendCarePage/AttendCareNoticePage/PhotoAlbumView.tsx
+++ b/src/pages/AdminAttendCarePage/AttendCareNoticePage/PhotoAlbumView.tsx
@@ -15,8 +15,10 @@ export function PhotoAlbumView() {
         text="견주에게 사진과 코멘트를 남겨 보세요"
         onClick={() => navigate(routes.admin.care.gallery.dynamic(dogId))}
       />
-      <Flex direction="column" gap={20} pt={32}>
-        <Text typo="body2_16_B">전송된 사진</Text>
+      <Flex direction="column" gap={16} pt={32}>
+        <Text typo="body2_16_B" color="gray_1">
+          전송된 사진
+        </Text>
         <PhotoAlbum dogId={Number(dogId)} />
       </Flex>
     </Box>

--- a/src/pages/AdminAttendCarePage/AttendCareNoticePage/PhotoAlbumView.tsx
+++ b/src/pages/AdminAttendCarePage/AttendCareNoticePage/PhotoAlbumView.tsx
@@ -3,11 +3,10 @@ import { routes } from "constants/path";
 import MainSendCard from "components/Admin/AttendCare/button/MainSendCard";
 import { PhotoAlbum } from "components/Admin/AttendCareNotice/PhotoAlbum";
 import { Box, Flex, Text } from "components/common";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
-export function PhotoAlbumView() {
+export function PhotoAlbumView({ dogId }: { dogId: number }) {
   const navigate = useNavigate();
-  const { dogId } = useParams<{ dogId: string }>();
 
   return (
     <Box paddingBlock={24}>
@@ -19,7 +18,7 @@ export function PhotoAlbumView() {
         <Text typo="body2_16_B" color="gray_1">
           전송된 사진
         </Text>
-        <PhotoAlbum dogId={Number(dogId)} />
+        <PhotoAlbum dogId={dogId} />
       </Flex>
     </Box>
   );

--- a/src/pages/AdminDogDetailInfoPage/AttendanceRecord.tsx
+++ b/src/pages/AdminDogDetailInfoPage/AttendanceRecord.tsx
@@ -2,23 +2,28 @@ import DogCircleIcon from "assets/svg/dog-circle-icon";
 import { Calendar, DailyAgenda } from "components/Admin/DogDetailInfo/AttendanceRecord";
 import { Box } from "components/common";
 import { format, parseISO } from "date-fns";
+import { useGetCachedDogDetail } from "hooks/api/admin/dogs";
 import { Suspense } from "react";
 import { useSearchParams } from "react-router-dom";
 import styled from "styled-components";
-import { Img } from "styles/StyleModule";
 
 export function AttendanceRecord({ dogId }: { dogId: number }) {
   const [searchParams] = useSearchParams();
   const date = searchParams.get("date") || format(new Date(), "yyyy-MM-dd");
   const today = format(parseISO(date), "M월 d일");
 
+  const { data } = useGetCachedDogDetail(dogId);
+
   return (
     <>
       <TopContainer>
         <ProfileImgWrapper>
-          {/* TODO: 프로필사진 받아오기*/}
-          {/*<Img src={} />*/}
-          <DogCircleIcon w={52} h={52} colorScheme={"gray"} />
+          <Image
+            src={
+              data.profileUri ??
+              process.env.REACT_APP_CLIENT_BASE_URL + "images/placeholder-image.png"
+            }
+          />
         </ProfileImgWrapper>
       </TopContainer>
       <Suspense fallback={<div>캘린더 로딩중...</div>}>
@@ -39,6 +44,9 @@ export function AttendanceRecord({ dogId }: { dogId: number }) {
 AttendanceRecord.Skeleton = () => <div>등원기록 스켈레톤...</div>;
 
 const TopContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   height: 7vh;
   min-height: 59px;
   border-radius: 20px 20px 0 0;
@@ -49,10 +57,16 @@ const ProfileImgWrapper = styled.div`
   position: relative;
   width: 52px;
   height: 52px;
-  margin: 0 auto;
   border-radius: 50%;
+  overflow: hidden;
   transform: translateY(3vh);
   z-index: 2;
+`;
+
+const Image = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 `;
 
 const AgendaContainer = styled.div`

--- a/src/pages/AdminDogDetailInfoPage/DogDetailInfoPage.tsx
+++ b/src/pages/AdminDogDetailInfoPage/DogDetailInfoPage.tsx
@@ -6,7 +6,7 @@ import { Box, Layout } from "components/common";
 import Header from "components/common/Header";
 import { Tabs } from "components/common/Tabs";
 import { useDogInfoData } from "hooks/api/admin/dogs";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Suspense } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import styled from "styled-components";

--- a/src/pages/AdminMyPage/AdminSettingPage.tsx
+++ b/src/pages/AdminMyPage/AdminSettingPage.tsx
@@ -36,7 +36,7 @@ const AdminSettingPage = () => {
               <Text typo="body2_16_R" color="gray_1">
                 알림 설정
               </Text>
-              <ArrowRightIcon colorScheme="gray_3" size={20} />
+              <ArrowRightIcon color="gray_3" size={20} />
             </Box>
             <Box
               display="flex"
@@ -50,7 +50,7 @@ const AdminSettingPage = () => {
               <Text typo="body2_16_R" color="gray_1">
                 정책
               </Text>
-              <ArrowRightIcon colorScheme="gray_3" size={20} />
+              <ArrowRightIcon color="gray_3" size={20} />
             </Box>
             <Box
               display="flex"
@@ -89,7 +89,7 @@ const AdminSettingPage = () => {
               <Text typo="body2_16_R" color="gray_1">
                 탈퇴하기
               </Text>
-              <ArrowRightIcon colorScheme="gray_3" size={20} />
+              <ArrowRightIcon color="gray_3" size={20} />
             </Box>
           </Layout>
         </>

--- a/src/pages/MemberPage/MemberSettingPage.tsx
+++ b/src/pages/MemberPage/MemberSettingPage.tsx
@@ -36,7 +36,7 @@ const MemberSettingPage = () => {
               <Text typo="body2_16_R" color="gray_1">
                 알림 설정
               </Text>
-              <ArrowRightIcon colorScheme="gray_3" size={20} />
+              <ArrowRightIcon color="gray_3" size={20} />
             </Box>
             <Box
               display="flex"
@@ -50,7 +50,7 @@ const MemberSettingPage = () => {
               <Text typo="body2_16_R" color="gray_1">
                 정책
               </Text>
-              <ArrowRightIcon colorScheme="gray_3" size={20} />
+              <ArrowRightIcon color="gray_3" size={20} />
             </Box>
             <Box
               display="flex"
@@ -89,7 +89,7 @@ const MemberSettingPage = () => {
               <Text typo="body2_16_R" color="gray_1">
                 탈퇴하기
               </Text>
-              <ArrowRightIcon colorScheme="gray_3" size={20} />
+              <ArrowRightIcon color="gray_3" size={20} />
             </Box>
           </Layout>
         </>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

- admin 강아지 관리 상세페이지 - 강아지 정보(이름, 프로필) 표시 로직 변경
- admin 출석부 강아지 상세페이지 - 등원기록 탭에서 강아지 프로필 이미지가 표시되지 않는 문제 수정
- admin 강아지 관리 상세페이지 > 사진 앨범 로직 변경

현재 해당 페이지에서 사용된 API로는 필요한 데이터(이미지, 이름)를 받을 수 없는 한계가 있어, 이전에 조회한 데이터를 재사용하기 위해 TanStack Query의 QueryCache를 활용하여 필요한 정보를 활용할 수 있도록 개선했습니다.

관련 QA: https://www.notion.so/11c6c15f67fb80b98619f9188a803c69?pvs=4


## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

#### QueryCache를 활용한 강아지 정보 표시 개선
   - 상세 페이지에서 메인 페이지에서 호출된 후 캐시된 데이터를 재사용했습니다.
   - 캐시된 데이터가 없는 경우 메인 페이지 API를 호출하여 필요한 데이터를 가져오도록 처리했습니다

   ```typescript
// 강아지 관리 메인 조회
export const useGetCareDogList = (initialData: CareDogInfo[]) => {
  return useSuspenseQuery<CareDogInfo[]>({
    queryKey: QUERY_KEY.CARE_DOG_LIST,
    queryFn: () => handleGetCareDogs(),
    initialData
  });
};

// 강아지 관리 상세 - 캐시된 강아지 목록 조회
export const useGetCachedCareDog = (dogId: number) => {
  const queryClient = useQueryClient();

  return useSuspenseQuery<CareDogInfo, Error>({
    queryKey: ["careDogDetail", dogId],
    queryFn: async () => {
      // 1. 캐시된 리스트 데이터 찾기
      const cachedList = queryClient.getQueryData<CareDogInfo[]>(QUERY_KEY.CARE_DOG_LIST);
      const cachedDog = cachedList?.find((dog) => dog.dogId === dogId);

      if (cachedDog) {
        return cachedDog;
      }

      // 2. 캐시에 없다면 메인 페이지 API 다시 호출
      const updatedList = await handleGetCareDogs();
      const updatedDog = updatedList.find((dog) => dog.dogId === dogId);

      if (updatedDog) {
        // 메인 페이지 캐시 업데이트
        queryClient.setQueryData(QUERY_KEY.CARE_DOG_LIST, updatedList);
        return updatedDog;
      }

      // 3. 새로운 리스트에서도 없는경우(e.g. 강아지 삭제) 에러 throw
      throw new Error(`데이터가 존재하지 않습니다. dogId: ${dogId}`);
    },
    staleTime: 5 * 60 * 1000 // 5분 동안 fresh 상태 유지
  });
};
```

#### 강아지 관리 - 사진 앨범 로직 변경
- 앨범에서 최대 4장까지 사진을 표시하고, 남은 사진 개수를 표시하도록 수정했습니다

