### PR TITLE
fix/ui: 어드민 사진 상세 보기 이미지 비율 수정

### DIFF
--- a/src/components/Admin/DogGallery/GalleryViewer/MediaDetailPopup/index.tsx
+++ b/src/components/Admin/DogGallery/GalleryViewer/MediaDetailPopup/index.tsx
@@ -1,6 +1,7 @@
 import { ModalProps } from "components/common/Modal";
 import Portal from "components/common/Portal";
 import { AnimatePresence } from "framer-motion";
+import { useRef, useState, useEffect } from "react";
 
 import * as S from "./styles";
 
@@ -9,9 +10,58 @@ interface MediaDetailPopupProps extends ModalProps {
 }
 
 const MediaDetailPopup = ({ isOpen, close, uri }: MediaDetailPopupProps) => {
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const [scale, setScale] = useState<number>(1);
+  const [touchDistance, setTouchDistance] = useState<number | null>(null);
+
   const handleOverlayClose = () => {
     close();
   };
+
+  const calculateDistance = (touches: TouchList) => {
+    const [touch1, touch2] = [touches[0], touches[1]];
+    return Math.sqrt(
+      Math.pow(touch2.clientX - touch1.clientX, 2) + Math.pow(touch2.clientY - touch1.clientY, 2)
+    );
+  };
+
+  const handleTouchStart = (e: TouchEvent) => {
+    if (e.touches.length === 2) {
+      const initialDistance = calculateDistance(e.touches);
+      setTouchDistance(initialDistance);
+    }
+  };
+
+  const handleTouchMove = (e: TouchEvent) => {
+    if (e.touches.length === 2 && touchDistance !== null) {
+      const currentDistance = calculateDistance(e.touches);
+      const scaleChange = currentDistance / touchDistance;
+      setScale((prevScale) => Math.max(1, Math.min(prevScale * scaleChange, 3))); // 최소 배율 1, 최대 배율 3
+      setTouchDistance(currentDistance);
+    }
+  };
+
+  const handleTouchEnd = () => {
+    setTouchDistance(null);
+  };
+
+  useEffect(() => {
+    const imgElement = imgRef.current;
+
+    if (!imgElement) return;
+
+    // 터치 이벤트 등록
+    imgElement.addEventListener("touchstart", handleTouchStart);
+    imgElement.addEventListener("touchmove", handleTouchMove);
+    imgElement.addEventListener("touchend", handleTouchEnd);
+
+    // 컴포넌트가 언마운트될 때 이벤트 해제
+    return () => {
+      imgElement.removeEventListener("touchstart", handleTouchStart);
+      imgElement.removeEventListener("touchmove", handleTouchMove);
+      imgElement.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [touchDistance]);
 
   return (
     <AnimatePresence mode="wait">
@@ -20,7 +70,12 @@ const MediaDetailPopup = ({ isOpen, close, uri }: MediaDetailPopupProps) => {
           <S.Wrapper>
             <S.FloatingOverlay onClick={handleOverlayClose}>
               <S.DetailsImgBox>
-                <img src={uri} />
+                <img
+                  ref={imgRef}
+                  src={uri}
+                  alt="Detailed View"
+                  style={{ transform: `scale(${scale})`, transformOrigin: "center center" }}
+                />
               </S.DetailsImgBox>
             </S.FloatingOverlay>
           </S.Wrapper>

--- a/src/components/Admin/DogGallery/GalleryViewer/MediaDetailPopup/index.tsx
+++ b/src/components/Admin/DogGallery/GalleryViewer/MediaDetailPopup/index.tsx
@@ -1,7 +1,6 @@
 import { ModalProps } from "components/common/Modal";
 import Portal from "components/common/Portal";
 import { AnimatePresence } from "framer-motion";
-import { useRef, useState, useEffect } from "react";
 
 import * as S from "./styles";
 
@@ -10,58 +9,9 @@ interface MediaDetailPopupProps extends ModalProps {
 }
 
 const MediaDetailPopup = ({ isOpen, close, uri }: MediaDetailPopupProps) => {
-  const imgRef = useRef<HTMLImageElement | null>(null);
-  const [scale, setScale] = useState<number>(1);
-  const [touchDistance, setTouchDistance] = useState<number | null>(null);
-
   const handleOverlayClose = () => {
     close();
   };
-
-  const calculateDistance = (touches: TouchList) => {
-    const [touch1, touch2] = [touches[0], touches[1]];
-    return Math.sqrt(
-      Math.pow(touch2.clientX - touch1.clientX, 2) + Math.pow(touch2.clientY - touch1.clientY, 2)
-    );
-  };
-
-  const handleTouchStart = (e: TouchEvent) => {
-    if (e.touches.length === 2) {
-      const initialDistance = calculateDistance(e.touches);
-      setTouchDistance(initialDistance);
-    }
-  };
-
-  const handleTouchMove = (e: TouchEvent) => {
-    if (e.touches.length === 2 && touchDistance !== null) {
-      const currentDistance = calculateDistance(e.touches);
-      const scaleChange = currentDistance / touchDistance;
-      setScale((prevScale) => Math.max(1, Math.min(prevScale * scaleChange, 3))); // 최소 배율 1, 최대 배율 3
-      setTouchDistance(currentDistance);
-    }
-  };
-
-  const handleTouchEnd = () => {
-    setTouchDistance(null);
-  };
-
-  useEffect(() => {
-    const imgElement = imgRef.current;
-
-    if (!imgElement) return;
-
-    // 터치 이벤트 등록
-    imgElement.addEventListener("touchstart", handleTouchStart);
-    imgElement.addEventListener("touchmove", handleTouchMove);
-    imgElement.addEventListener("touchend", handleTouchEnd);
-
-    // 컴포넌트가 언마운트될 때 이벤트 해제
-    return () => {
-      imgElement.removeEventListener("touchstart", handleTouchStart);
-      imgElement.removeEventListener("touchmove", handleTouchMove);
-      imgElement.removeEventListener("touchend", handleTouchEnd);
-    };
-  }, [touchDistance]);
 
   return (
     <AnimatePresence mode="wait">
@@ -70,12 +20,7 @@ const MediaDetailPopup = ({ isOpen, close, uri }: MediaDetailPopupProps) => {
           <S.Wrapper>
             <S.FloatingOverlay onClick={handleOverlayClose}>
               <S.DetailsImgBox>
-                <img
-                  ref={imgRef}
-                  src={uri}
-                  alt="Detailed View"
-                  style={{ transform: `scale(${scale})`, transformOrigin: "center center" }}
-                />
+                <img src={uri} alt="Detailed View" />
               </S.DetailsImgBox>
             </S.FloatingOverlay>
           </S.Wrapper>

--- a/src/components/Admin/DogGallery/GalleryViewer/VideoPlayer/style.ts
+++ b/src/components/Admin/DogGallery/GalleryViewer/VideoPlayer/style.ts
@@ -2,7 +2,9 @@ import styled from "styled-components";
 
 export const Container = styled.div`
   position: relative;
-  height: 100%;
+  display: flex;
+  align-items: center;
+  height: calc(100vh - 48px - 180px);
   width: 100%;
 `;
 

--- a/src/components/Admin/DogGallery/GalleryViewer/index.tsx
+++ b/src/components/Admin/DogGallery/GalleryViewer/index.tsx
@@ -16,7 +16,6 @@ interface GalleryProps {
   onChangeSelected?: (item: MediaItem) => void;
 }
 
-// 전체 Gallery 컴포넌트
 const GalleryViewer = ({ mediaItems = [], selectedMedia, onChangeSelected }: GalleryProps) => {
   const overlay = useOverlay();
   const sliderRef = useRef<Slider | null>(null);

--- a/src/components/Admin/DogGallery/GalleryViewer/styles.ts
+++ b/src/components/Admin/DogGallery/GalleryViewer/styles.ts
@@ -12,19 +12,24 @@ export const GalleryWrapper = styled.div`
 export const MainMediaDisplayWrapper = styled.div`
   overflow: hidden;
   width: 100%;
-  height: calc(100vh - 48px - 180px);
   margin-bottom: 1rem;
 `;
 
 export const MainMediaDisplayList = styled.div`
   width: 100%;
   height: 100%;
+  .slick-slide {
+    img {
+      height: calc(100vh - 48px - 180px);
+      object-fit: cover;
+    }
+  }
 `;
 
 export const MainMediaDisplay = styled.div<{ $isVideo: boolean }>`
   flex: 0 0 100%;
   height: 100%;
-  transform: ${({ $isVideo }) => ($isVideo ? "translateY(50%)" : "none")};
+  // transform: ${({ $isVideo }) => ($isVideo ? "translateY(50%)" : "none")};
 `;
 
 export const SelectedMediaImage = styled.img`
@@ -56,7 +61,7 @@ export const ThumbnailItemsList = styled.div`
 `;
 
 export const ThumbnailItemContainer = styled.div<{ $isSelected: boolean }>`
-  width: 3.4rem;
+  width: 4rem;
   height: 4.5rem;
   display: flex;
   padding-left: ${({ $isSelected }) => ($isSelected ? "6px" : "0")};


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

어드민의 사진 상세 페이지에서 발생한 이미지 비율 이슈를 수정하였습니다.
[관련 이슈 노션](https://www.notion.so/1216c15f67fb8025bf1df67a69c2012b?pvs=4)



## 작업 내용
- 기존에 이미지가 잘리는 문제가 있었던 사진 상세 페이지에서 이미지 비율을 조정했습니다.
- 하단 이미지 리스트와 메인 이미지의 비율을 맞추기 위해 메인 이미지의 너비를 조정하였습니다.

## 스크린샷

![스크린샷 2024-10-17 오후 2 25 05](https://github.com/user-attachments/assets/e3c552ab-ba20-4d3a-aa64-b701e3d453cf)

@seongnam95 @jieun419 @im-na0 @Ryusunshine 